### PR TITLE
To allow disable omnicompl for specific ft.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To register a LSP server, add the following lines to your .vimrc file:
 		\	'filetype': ['javascript', 'typescript'],
 		\	'path': '/usr/local/bin/typescript-language-server',
 		\	'args': ['--stdio']
-		\     }
+		\     },
 		\     {
 		\	'filetype': 'sh',
 		\	'path': '/usr/local/bin/bash-language-server',

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -122,7 +122,7 @@ file types, add the following commands to the .vimrc file: >
 		\	'filetype': ['javascript', 'typescript'],
 		\	'path': '/usr/local/bin/typescript-language-server',
 		\	'args': ['--stdio']
-		\     }
+		\     },
 		\     {
 		\	'filetype': 'python',
 		\	'path': '/usr/local/bin/pyls',
@@ -357,13 +357,32 @@ use the keys described in |popupmenu-keys| with this menu.
 To disable the auto-compeltion, you can set the LSP_24x7_Complete variable
 to v:false in your .vimrc file: >
 
-	let g:LSP_24x7_Complete=v:false
+	let g:LSP_24x7_Complete = v:false
 <
 If this variable is set, then the LSP plugin doesn't automatically start
 completion in insert mode and instead supports omni-completion (|compl-omni|).
 It sets the 'omnifunc' option for the buffers which have a registered LSP
 server. To complete a symbol in insert mode manually, you can press CTRL-X
 CTRL-O to invoke completion using the items suggested by the LSP server.
+
+And also indeed e.g: >
+
+	let lspServers = [
+		\     {
+		\	'filetype': ['javascript', 'typescript'],
+		\	'omnicompl': v:true,
+		\	'path': '/usr/local/bin/typescript-language-server',
+		\	'args': ['--stdio']
+		\     },
+		\     {
+		\	'filetype': 'python',
+		\	'omnicompl': v:false,
+		\	'path': '/usr/local/bin/pyls',
+		\	'args': ['--check-parent-process', '-v']
+		\     }
+		\   ]
+<
+adding "omnicompl" into configuration to set for specific ft, default is true.
 
 ==============================================================================
 


### PR DESCRIPTION
// when `let g:LSP_24x7_Complete = v:false`,
some compl from lsp maybe not a good way / user like,
or whatever user may like his/her preferred omnifunc which not override by this plugin.

```vim
	let lspServers = [
		\     {
		\	'filetype': ['javascript', 'typescript'],
		\	'omnicompl': v:true,
		\	'path': '/usr/local/bin/typescript-language-server',
		\	'args': ['--stdio']
		\     },
		\     {
		\	'filetype': 'python',
		\	'omnicompl': v:false,
		\	'path': '/usr/local/bin/pyls',
		\	'args': ['--check-parent-process', '-v']
		\     }
		\   ]
```

To allow user can disable omnicompl for specific ft.
- adding a 'omnicompl' option in configuration.
- default (or if not set) 'omnicompl' is true.
