### PR TITLE
disable auto showSignature

### DIFF
--- a/autoload/handlers.vim
+++ b/autoload/handlers.vim
@@ -25,7 +25,7 @@ def s:processInitializeReply(lspserver: dict<any>, req: dict<any>, reply: dict<a
   # and then setup the below mapping for those buffers.
 
   # map characters that trigger signature help
-  if caps->has_key('signatureHelpProvider')
+  if g:LSP_Show_Signature && caps->has_key('signatureHelpProvider')
     var triggers = caps.signatureHelpProvider.triggerCharacters
     for ch in triggers
       exe 'inoremap <buffer> <silent> ' .. ch .. ' ' .. ch .. "<C-R>=lsp#showSignature()<CR>"

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -306,7 +306,7 @@ def lsp#addFile(bnr: number): void
   exe 'autocmd InsertLeave <buffer=' .. bnr .. '> call lsp#leftInsertMode()'
 
   # map characters that trigger signature help
-  if lspserver.caps->has_key('signatureHelpProvider')
+  if g:LSP_Show_Signature && lspserver.caps->has_key('signatureHelpProvider')
     var triggers = lspserver.caps.signatureHelpProvider.triggerCharacters
     for ch in triggers
       exe 'inoremap <buffer> <silent> ' .. ch .. ' ' .. ch

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -210,10 +210,14 @@ accepts a list of LSP servers with the above information.
 
 						*:LspShowSignature*
 :LspShowSignature	Displays the signature of the symbol (e.g. a function
-			or method) before the cursor in a popup. The popup is
-			also automatically displayed in insert mode after
-			entering a symbol name followed by a separator (e.g. a
-			opening parenthesis).
+			or method) before the cursor in a popup.
+
+			The popup is also automatically displayed in insert
+			mode after entering a symbol name followed by a
+			separator (e.g. a opening parenthesis). Unless if: >
+			let g:LSP_Show_Signature = v:false
+<
+			Default is true.
 
 						*:LspDiagShow*
 :LspDiagShow		Creates a new location list with the diagnostics

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -11,6 +11,10 @@ if !exists('g:LSP_24x7_Complete')
   let g:LSP_24x7_Complete = v:true
 endif
 
+if !exists('g:LSP_Show_Signature')
+  let g:LSP_Show_Signature = v:true
+endif
+
 augroup LSPAutoCmds
   au!
   autocmd BufNewFile,BufReadPost *


### PR DESCRIPTION
- if g:LSP_24x7_Complete is false

// auto show signature looks a bit delay, not work smoothly always..
// specially those 'inoremap' would override user's key map, perhaps not a good idea..
// so should be better to enable auto show signature Like auto completion Only IF g:LSP_24x7_Complete is true (default though).