### PR TITLE
Add : Possibility to echo signature in cmdline

### DIFF
--- a/autoload/handlers.vim
+++ b/autoload/handlers.vim
@@ -120,15 +120,30 @@ def s:processSignaturehelpReply(lspserver: dict<any>, req: dict<any>, reply: dic
   if sig->has_key('parameters') && result->has_key('activeParameter')
     var params_len = sig.parameters->len()
     if params_len > 0 && result.activeParameter < params_len
-      var label = sig.parameters[result.activeParameter].label
+      var label = ''
+      if sig.parameters[result.activeParameter]->has_key('documentation')
+        label = sig.parameters[result.activeParameter].documentation
+      else
+        label = sig.parameters[result.activeParameter].label
+      endif
       hllen = label->len()
       startcol = text->stridx(label)
     endif
   endif
-  var popupID = text->popup_atcursor({moved: 'any'})
-  prop_type_add('signature', {bufnr: popupID->winbufnr(), highlight: 'LineNr'})
-  if hllen > 0
-    prop_add(1, startcol + 1, {bufnr: popupID->winbufnr(), length: hllen, type: 'signature'})
+  if g:LSP_Echo_Signature
+    echon "\r\r"
+    echon ''
+    echon strpart(text, 0, startcol)
+    echoh LineNr
+    echon strpart(text, startcol, hllen)
+    echoh None
+    echon strpart(text, startcol + hllen)
+  else
+    var popupID = text->popup_atcursor({moved: 'any'})
+    prop_type_add('signature', {bufnr: popupID->winbufnr(), highlight: 'LineNr'})
+    if hllen > 0
+      prop_add(1, startcol + 1, {bufnr: popupID->winbufnr(), length: hllen, type: 'signature'})
+    endif
   endif
 enddef
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -215,7 +215,9 @@ accepts a list of LSP servers with the above information.
 			The popup is also automatically displayed in insert
 			mode after entering a symbol name followed by a
 			separator (e.g. a opening parenthesis). Unless if: >
-			let g:LSP_Show_Signature = v:false
+			let g:LSP_Show_Signature = v:false. If you set
+			g:LSP_Show_Signature = 1 the signature will be echoed
+			in cmdline rather displayed in a popup.
 <
 			Default is true.
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -215,11 +215,15 @@ accepts a list of LSP servers with the above information.
 			The popup is also automatically displayed in insert
 			mode after entering a symbol name followed by a
 			separator (e.g. a opening parenthesis). Unless if: >
-			let g:LSP_Show_Signature = v:false. If you set
-			g:LSP_Show_Signature = 1 the signature will be echoed
-			in cmdline rather displayed in a popup.
+			let g:LSP_Show_Signature = v:false.
 <
 			Default is true.
+
+			You can get the function signature echoed in cmdline
+			rather than displayed in popup if you use
+			> let g:LSP_Echo_Signature = v:true
+<
+			Default is false
 
 						*:LspDiagShow*
 :LspDiagShow		Creates a new location list with the diagnostics

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -220,8 +220,8 @@ accepts a list of LSP servers with the above information.
 			Default is true.
 
 			You can get the function signature echoed in cmdline
-			rather than displayed in popup if you use
-			> let g:LSP_Echo_Signature = v:true
+			rather than displayed in popup if you use >
+			let g:LSP_Echo_Signature = v:true
 <
 			Default is false
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -15,6 +15,10 @@ if !exists('g:LSP_Show_Signature')
   let g:LSP_Show_Signature = v:true
 endif
 
+if !exists('g:LSP_Echo_Signature')
+  let g:LSP_Echo_Signature = v:false
+endif
+
 augroup LSPAutoCmds
   au!
   autocmd BufNewFile,BufReadPost *


### PR DESCRIPTION
This add an `g:LSP_Echo_Signature` option which permit to see signature of a symbol echoed in cmdline rather than displayed in a popup window.