### PR TITLE
Fix util#LspUriToFile with handler#processDocSymbolReply

### DIFF
--- a/autoload/util.vim
+++ b/autoload/util.vim
@@ -56,7 +56,8 @@ export def LspUriToFile(uri: string): string
     # MS-Windows URI
     uri_decoded = uri_decoded[8 : ]
     uri_decoded = uri_decoded->substitute('/', '\\', 'g')
-  else
+  # On GNU/Linux (pattern not end with `:`)
+  elseif uri_decoded =~? '^file:///\a'
     uri_decoded = uri_decoded[7 : ]
   endif
 


### PR DESCRIPTION
When get handler#processDocSymbol, textDocument.uri does not begin with
'file://', so util#LspUriToFile truncate the file name.