### PR TITLE
Fire event when LSP client is attached to a buffer

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -406,6 +406,8 @@ export def AddFile(bnr: number): void
     endif
   augroup END
 
+  doautocmd <nomodeline> User LspAttached
+
   buf.BufLspServerSet(bnr, lspserver)
 enddef
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -543,5 +543,11 @@ default. The following example disables omni-completion for python: >
 		\   ]
 <
 ==============================================================================
+7. Autocommands						*lsp-autocmds*
+
+							*LspAttached*
+LspAttached			A |User| autocommand fired when the LSP client
+				attaches to a buffer. Can be used to configure
+				buffer-local mappings or options.
 
 vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
This provides a hook for users to configure buffers that use LSP. For
example,

    autocmd User LSPAttached {
        nnoremap <buffer> <C-]> <Cmd>LspGotoDefinition<CR>
    }
