### PR TITLE
Use shiftwidth() as tabSize

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -718,17 +718,9 @@ def TextDocFormat(lspserver: dict<any>, fname: string, rangeFormat: bool,
 
   # interface DocumentFormattingParams
   # interface TextDocumentIdentifier
-  var tabsz: number
-  if &sts > 0
-    tabsz = &sts
-  elseif &sts < 0
-    tabsz = &shiftwidth
-  else
-    tabsz = &tabstop
-  endif
   # interface FormattingOptions
   var fmtopts: dict<any> = {
-    tabSize: tabsz,
+    tabSize: shiftwidth(),
     insertSpaces: &expandtab ? true : false,
   }
   #req.params->extend({textDocument: {uri: util.LspFileToUri(fname)},


### PR DESCRIPTION
The tabSize field in the LSP spec is poorly named, as it's not used for tabs but rather the indent size when formatting.  This corresponds to `shiftwidth()` in Vim.

This is also the approach taken by [coc.nvim](https://github.com/neoclide/coc.nvim/blob/287c743c9f227fdf0e1db452bbb8ae3c5caffc36/autoload/coc/util.vim#L868-L871) and [Neovim](https://github.com/neovim/neovim/blob/1184097261260e53519db54548acf2c1e5ab7e68/runtime/lua/vim/lsp/util.lua#L1905-L1906).

If there's some reason not to do this, the code should instead be updated to use `shiftwidth()` so that `shiftwidth=0` is handled correctly, and possibly to respect `'smarttab'`.