### PR TITLE
Send an `initialized` message after sending "initialize"

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -118,8 +118,16 @@ def StartServer(lspserver: dict<any>, isSync: bool = false): number
   lspserver.running = true
 
   lspserver.initServer(isSync)
+  lspserver.initialized(isSync)
 
   return 0
+enddef
+
+def Initialized(lspserver: dict<any>, isSync: bool = false)
+  var req = {}
+  req.jsonrpc = '2.0'
+  req.method = 'initialized'
+  lspserver.sendMessage(req)
 enddef
 
 # Request: 'initialize'
@@ -1045,6 +1053,7 @@ export def NewLspServer(path: string, args: list<string>): dict<any>
   lspserver->extend({
     startServer: function(StartServer, [lspserver]),
     initServer: function(InitServer, [lspserver]),
+    initialized: function(Initialized, [lspserver]),
     stopServer: function(StopServer, [lspserver]),
     shutdownServer: function(ShutdownServer, [lspserver]),
     exitServer: function(ExitServer, [lspserver]),


### PR DESCRIPTION
`rust-analyzer` will exit if we don't send an `initialized` message after sending the `initialize` message.  It doesn't seem like we really need to do anything to initialize, so this doesn't wait for the initialize request to return, it just sends the `initialized` message.

[Here is the message in the
spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized)

I'm mainly using this with `clangd` and `rust-analyzer` right now.  I verified that `clangd` still works after making this change, but I'm not sure how to write a test (sorry, I'm very new to writing Vim extensions 😅)