### PR TITLE
lspserver: sync property

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -497,7 +497,12 @@ export def AddServer(serverList: list<dict<any>>)
       return
     endif
 
-    var lspserver: dict<any> = lserver.NewLspServer(server.path, args)
+    if !server->has_key('sync')
+      server['sync'] = v:false
+    endif
+
+    var lspserver: dict<any> = lserver.NewLspServer(server.path, args,
+          \ server.sync)
 
     if server.filetype->type() == v:t_string
       LspAddServer(server.filetype, lspserver)

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -77,9 +77,7 @@ enddef
 
 # Start a LSP server
 #
-# If 'isSync' is true, then waits for the server to send the initialize
-# response message.
-def StartServer(lspserver: dict<any>, isSync: bool = false): number
+def StartServer(lspserver: dict<any>): number
   if lspserver.running
     util.WarnMsg("LSP server for is already running")
     return 0
@@ -117,7 +115,7 @@ def StartServer(lspserver: dict<any>, isSync: bool = false): number
   lspserver.job = job
   lspserver.running = true
 
-  lspserver.initServer(isSync)
+  lspserver.initServer()
 
   return 0
 enddef
@@ -125,9 +123,7 @@ enddef
 # Request: 'initialize'
 # Param: InitializeParams
 #
-# If 'isSync' is true, then waits for the server to send the initialize
-# response message.
-def InitServer(lspserver: dict<any>, isSync: bool = false)
+def InitServer(lspserver: dict<any>)
   var req = lspserver.createRequest('initialize')
 
   # client capabilities (ClientCapabilities)
@@ -176,7 +172,7 @@ def InitServer(lspserver: dict<any>, isSync: bool = false)
   req.params->extend(initparams)
 
   lspserver.sendMessage(req)
-  if isSync
+  if lspserver.sync
     lspserver.waitForResponse(req)
   endif
 enddef
@@ -1020,10 +1016,11 @@ def ShowCapabilities(lspserver: dict<any>)
   endfor
 enddef
 
-export def NewLspServer(path: string, args: list<string>): dict<any>
+export def NewLspServer(path: string, args: list<string>, isSync: bool): dict<any>
   var lspserver: dict<any> = {
     path: path,
     args: args,
+    sync: isSync,
     running: false,
     ready: false,
     job: v:none,

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -154,10 +154,10 @@ file types, add the following commands to the .vimrc file: >
 <
 Depending on the location of the typescript and python pyls language servers
 installed in your system, update the 'path' in the above snippet
-appripriately.
+appropriately.
 
-Another example, for adding the LSP servers for the C, C++, Shell script and
-Vim file types: >
+Another example, for adding the LSP servers for the C, C++, Golang, Rust, 
+Shell script and Vim file types: >
 
    let lspServers = [
 		\     #{
@@ -165,6 +165,20 @@ Vim file types: >
 		\        path: '/usr/local/bin/clangd',
 		\        args: ['--background-index']
 		\     },
+                \     #{ 
+                \        filetype: ['go', 'gomod', 'gohtmltmpl', 'gotexttmpl'],
+                \        path: '/home/dza/.go/bin/gopls',
+                \        args: [],
+                \        sync: v:true,
+                \        omnicompl: v:true,
+                \      },
+                \     #{
+                \        filetype: ['rust'],
+                \        path: '/home/dza/.cargo/bin/rust-analyzer',
+                \        args: [],
+                \        sync: v:true,
+                \        omnicompl: v:true,
+                \      },
 		\     #{
 		\	 filetype: 'sh',
 		\	 path: '/usr/local/bin/bash-language-server',
@@ -189,6 +203,10 @@ To add a LSP server, the following information is needed:
 			server. Each argument is a separate List item.
 	omnicompl	a boolean value that enables (true) or disables
 			(false) omni-completion for this file type.
+        sync            (Optional) for lsp servers that responds to a 
+                        'initialize'-request with a 'initialzed' response this
+                        should be set to 'v:true'. By default this is set to
+                        'v:false'.
 
 The LSP servers are added using the LspAddServer() function. This function
 accepts a list of LSP servers with the above information.


### PR DESCRIPTION
* Removes isSync as parameter from StartServer(..), InitServer(..)
* Adds isSync parameter to NewLspServer(...)
* Adds `sync` to lspserver-properties (Defaults to `sync: false` in LspServer dictionary).