### PR TITLE
LSPAutoCmds: ft-globs generated from filetype.vim

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -991,4 +991,21 @@ export def ShowServerCapabilities()
   lspserver.showCapabilities()
 enddef
 
+export def Ft2ExtGlob(ftype: string): string
+  var ft_detect: list<dict<any>> = autocmd_get({'group': 'filetypedetect', 'event': 'BufRead'})
+  if (!empty(ft_detect))
+    var found_ft: list<dict<any>> = ft_detect->filter($'v:val["cmd"] == "setf {ftype}"')
+    if (!empty(found_ft))
+      var ft_glob: string = found_ft->mapnew("v:val['pattern']")->join(',')
+      return ft_glob
+    endif
+  endif
+  return ""
+enddef
+
+# Show filetypes handled by LSP
+export def EnabledFt(): list<string>
+  return ftypeServerMap->keys()
+enddef
+
 # vim: shiftwidth=2 softtabstop=2

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -367,8 +367,12 @@ export def AddFile(bnr: number): void
 
   # set options for insert mode completion
   if opt.lspOptions.autoComplete
-    setbufvar(bnr, '&completeopt', 'menuone,popup,noinsert,noselect')
-    setbufvar(bnr, '&completepopup', 'border:off')
+    if !exists('&completeopt')
+      setbufvar(bnr, '&completeopt', 'menuone,popup,noinsert,noselect')
+    endif
+    if !exists('&completepopup')
+      setbufvar(bnr, '&completepopup', 'border:off')
+    endif
     # <Enter> in insert mode stops completion and inserts a <Enter>
     if !opt.lspOptions.noNewlineInCompletion
       inoremap <expr> <buffer> <CR> pumvisible() ? "\<C-Y>\<CR>" : "\<CR>"

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -167,6 +167,7 @@ def InitServer(lspserver: dict<any>)
 	name: fnamemodify(curdir, ':t'),
 	uri: util.LspFileToUri(curdir)
      }]
+  # [off|message|verbose]
   initparams.trace = 'off'
   initparams.capabilities = clientCaps
   req.params->extend(initparams)

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -13,7 +13,6 @@ endif
 var opt = {}
 var util = {}
 var lspf = {}
-var doc = {}
 if has('patch-8.2.4257')
   import '../autoload/lsp/util.vim' as util_import
   import '../autoload/lsp/lspoptions.vim' as lspoptions


### PR DESCRIPTION
I have a few improvements while working on the markdown-popup.

```LSPAutoCmds``` -> ```g:LspUpdateAutocmds```
1. Builds an extension glob (*.rs for rust for example) by reading each 'filetype'-property in lspservers-dict and converting to extensions by the `filetypedetect`-augroup ([filetype.vim](https://github.com/vim/vim/blob/master/runtime/filetype.vim)). I think this is the best or most integral solution there is, because vim does not provide any `filetype` => `*.extglobs` by itself.

2. Small improvement to being unassuming about preferences for user-set options such as `completepopup`, `completeopt` to retain as much customization as possible.

_Minor_: 
Comment added for `initparams.trace` (autoload/lsp/lspserver.vim);
`# [off, message, verbose]`.

`initparams.trace = 'message'` gives an error btw:

```
Error detected while processing BufRead Autocommands for "*.rs"..function lsp#lsp#AddFile[25]..<SNR>13_TextdocDidOpen[12]..<SNR>13_SendMessage:
line    8:
E630: ch_sendraw(): Write while not connected
```
Probably a minor issue.