### PR TITLE
Provide LSP server initializationOptions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ To register a LSP server, add the following lines to your .vimrc file (use only 
 		\	 filetype: ['fortran'],
 		\	 path: '/usr/local/bin/fortls',
 		\	 args: ['--nthreads=1', '--use_signature_help', '--hover_signature']
+		\      },
+		\     #{
+		\        filetype: ['php'],
+		\        path: '/usr/local/bin/intelephense',
+		\        args: ['--stdio'],
+		\        syncInit: v:true,
+		\        initializationOptions: {
+		\          licenceKey: 'xxxxxxxxxxxxxxx'
+		\        }
 		\      }
 		\   ]
    call LspAddServer(lspServers)

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -492,6 +492,16 @@ export def AddServer(serverList: list<dict<any>>)
     else
 
     endif
+
+    var initializationOptions: dict<any> = {}
+    if server->has_key('initializationOptions')
+      if server.initializationOptions->type() != v:t_dict
+        util.ErrMsg('Error: initializationOptions for LSP server ' .. server.initializationOptions .. ' is not a Dictionary')
+        return
+      endif
+      initializationOptions = server.initializationOptions
+    endif
+
     if server.omnicompl->type() != v:t_bool
       util.ErrMsg('Error: Setting of omnicompl ' .. server.omnicompl .. ' is not a Boolean')
       return
@@ -501,8 +511,10 @@ export def AddServer(serverList: list<dict<any>>)
       server.syncInit = v:false
     endif
 
-    var lspserver: dict<any> = lserver.NewLspServer(server.path, args,
-						    server.syncInit)
+    var lspserver: dict<any> = lserver.NewLspServer(server.path,
+						    args,
+						    server.syncInit,
+						    initializationOptions)
 
     if server.filetype->type() == v:t_string
       LspAddServer(server.filetype, lspserver)

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -169,6 +169,9 @@ def InitServer(lspserver: dict<any>)
      }]
   initparams.trace = 'off'
   initparams.capabilities = clientCaps
+  if !empty(lspserver.initializationOptions)
+    initparams.initializationOptions = lspserver.initializationOptions
+  endif
   req.params->extend(initparams)
 
   lspserver.sendMessage(req)
@@ -1016,11 +1019,12 @@ def ShowCapabilities(lspserver: dict<any>)
   endfor
 enddef
 
-export def NewLspServer(path: string, args: list<string>, isSync: bool): dict<any>
+export def NewLspServer(path: string, args: list<string>, isSync: bool, initializationOptions: dict<any>): dict<any>
   var lspserver: dict<any> = {
     path: path,
     args: args,
     syncInit: isSync,
+    initializationOptions: initializationOptions,
     running: false,
     ready: false,
     job: v:none,

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -157,7 +157,7 @@ installed in your system, update the 'path' in the above snippet
 appropriately.
 
 Another example, for adding the LSP servers for the C, C++, Golang, Rust, 
-Shell script and Vim file types: >
+Shell script, Vim script and PHP file types: >
 
    let lspServers = [
 		\     #{
@@ -186,7 +186,16 @@ Shell script and Vim file types: >
 		\	 filetype: ['vim'],
 		\	 path: '/usr/local/bin/vim-language-server',
 		\	 args: ['--stdio']
-		\     }
+		\     },
+		\     #{
+		\        filetype: ['php'],
+		\        path: '/usr/local/bin/intelephense',
+		\        args: ['--stdio'],
+		\        syncInit: v:true,
+		\        initializationOptions: {
+		\          licenceKey: 'xxxxxxxxxxxxxxx'
+		\        }
+		\      }
 		\   ]
    call LspAddServer(lspServers)
 <
@@ -208,6 +217,12 @@ To add a LSP server, the following information is needed:
 			to true, then a synchronous call is used to initialize
 			the LSP server, otherwise the server is initialized
 			asynchronously. By default this is set to 'v:false'.
+	initializationOptions
+			(Optional) for lsp servers (e.g. intelephense) some
+			additional initialization options may be required
+			or useful for initialization. Those can be provided in
+			this dictionary and if present will be transmitted to
+			the lsp server.
 
 The LSP servers are added using the LspAddServer() function. This function
 accepts a list of LSP servers with the above information.


### PR DESCRIPTION
This is to add support for LSP server initializationOptions. For me it was important to allow transmission of the licenseKey to the intelephense PHP language server, however it is a standard field and other servers configurations may require these too.

Some of configurations are (or may be) expected to be determined by the editor ('LSP client') however this should require individual per-server 'wrappers' or something similar.

* Add 'initializationOptions' as LSP server configuration option.
* Check if 'initializationOptions' are not empty and if so transmit these to the LSP server
* Updated README.md
* Updated plugin documentation