### PR TITLE
Add option to show diagnostics in a popup

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -201,7 +201,11 @@ export def ShowCurrentDiag(lspserver: dict<any>)
   if diag->empty()
     util.WarnMsg('No diagnostic messages found for current line')
   else
-    echo diag.message
+    if opt.lspOptions.showDiagInPopup
+      popup_atcursor(diag.message, { moved: 'any' })
+    else
+      echo diag.message
+    endif
   endif
 enddef
 

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -202,7 +202,11 @@ export def ShowCurrentDiag(lspserver: dict<any>)
     util.WarnMsg('No diagnostic messages found for current line')
   else
     if opt.lspOptions.showDiagInPopup
-      popup_atcursor(diag.message, { moved: 'any' })
+      popup_atcursor(
+        diag.message,
+        {
+          moved: 'any'
+        })
     else
       echo diag.message
     endif

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -33,7 +33,9 @@ export var lspOptions: dict<any> = {
   # Show a diagnostic message on a status line
   showDiagOnStatusLine: false,
   # Don't print message when a configured language server is missing.
-  ignoreMissingServer: false
+  ignoreMissingServer: false,
+  # Make diagnostics show in a popup instead of echoing
+  showDiagInPopup: true
 }
 
 # set LSP options from user provided options

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -35,7 +35,7 @@ export var lspOptions: dict<any> = {
   # Don't print message when a configured language server is missing.
   ignoreMissingServer: false,
   # Make diagnostics show in a popup instead of echoing
-  showDiagInPopup: true
+  showDiagInPopup: false
 }
 
 # set LSP options from user provided options

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -264,6 +264,9 @@ showDiagOnStatusLine	Show a diagnostic message on a status line.
 			By default this is set to false.
 ignoreMissingServer	Do not print a missing language server executable.
 			By default this is set to false.
+showDiagInPopup		Use a popup to display server diagnostics instead of
+			echoing.
+			By default this is set to false.
 
 For example, to disable the automatic placement of signs for the LSP
 diagnostic messages, you can add the following line to your .vimrc file:


### PR DESCRIPTION
Added a option to show diagnostics in a floating popup

![image](https://user-images.githubusercontent.com/115833146/197886483-3930a666-47d8-49cf-b9fa-12569f4eb5d3.png)

The option name is `showDiagInPopup` and it's default is `false`