### PR TITLE
Fix new lines in completion popup and in the completion detail popup

### DIFF
--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -124,7 +124,12 @@ def ProcessCompletionReply(lspserver: dict<any>, req: dict<any>, reply: dict<any
       d.info = 'Lazy doc'
     else
       if item->has_key('detail')
-        d.menu = item.detail
+        # Solve a issue where if a server send a detail field
+        # with a "\n", on the menu will be everything joined with
+        # a "^@" separating it. (example: clangd)
+        var splitted_detail = split(item.detail, "\n")
+
+        d.menu = splitted_detail[0]
       endif
       if item->has_key('documentation')
         if item.documentation->type() == v:t_string && item.documentation != ''
@@ -209,7 +214,10 @@ def ProcessResolveReply(lspserver: dict<any>, req: dict<any>, reply: dict<any>):
   var infoKind: string
 
   if reply.result->has_key('detail')
-    infoText->extend([reply.result.detail])
+    # Solve a issue where if a server send the detail field with "\n",
+    # on the completion popup, everything will be joined with "^@"
+    # (example: typescript-language-server)
+    infoText->extend(split(reply.result.detail, "\n"))
   endif
 
   if reply.result->has_key('documentation')

--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -127,9 +127,7 @@ def ProcessCompletionReply(lspserver: dict<any>, req: dict<any>, reply: dict<any
         # Solve a issue where if a server send a detail field
         # with a "\n", on the menu will be everything joined with
         # a "^@" separating it. (example: clangd)
-        var splitted_detail = split(item.detail, "\n")
-
-        d.menu = splitted_detail[0]
+        d.menu = item.detail->split("\n")[0]
       endif
       if item->has_key('documentation')
         if item.documentation->type() == v:t_string && item.documentation != ''


### PR DESCRIPTION
Fix some new line issues in the completion popup and in the completion detail popup

## Completion popup (menu):
> Before:
![image](https://user-images.githubusercontent.com/115833146/198087604-8d82ed48-327a-4628-9237-0a2b4d4fcc3f.png)

> After:
![image](https://user-images.githubusercontent.com/115833146/198087666-f38d14fd-c536-456b-8cbc-369720f7280d.png)

## Completion popup (detail preview):
> Before:
![image](https://user-images.githubusercontent.com/115833146/198087805-214ac7c0-afa9-4943-90c4-8d64af480c99.png)

> After:
![image](https://user-images.githubusercontent.com/115833146/198087859-3f6804ca-f5c5-4f1f-967d-2d47eef29573.png)