### PR TITLE
Create custom popup for code action and added a option to enable/disable it

### DIFF
--- a/autoload/lsp/codeaction.vim
+++ b/autoload/lsp/codeaction.vim
@@ -23,10 +23,6 @@ export def HandleCodeAction(lspserver: dict<any>, selAction: dict<any>)
   endif
 enddef
 
-def Print(a: any)
-  echo string(a)
-enddef
-
 export def ApplyCodeAction(lspserver: dict<any>, actions: list<dict<any>>): void
   if actions->empty()
     # no action can be performed

--- a/autoload/lsp/codeaction.vim
+++ b/autoload/lsp/codeaction.vim
@@ -4,38 +4,9 @@ vim9script
 
 import './util.vim'
 import './textedit.vim'
+import './options.vim' as opt
 
-export def ApplyCodeAction(lspserver: dict<any>, actions: list<dict<any>>): void
-  if actions->empty()
-    # no action can be performed
-    util.WarnMsg('No code action is available')
-    return
-  endif
-
-  var prompt: list<string> = ['Code Actions:']
-  var act: dict<any>
-  for i in range(actions->len())
-    act = actions[i]
-    var t: string = act.title->substitute('\r\n', '\\r\\n', 'g')
-    t = t->substitute('\n', '\\n', 'g')
-    prompt->add(printf("%d. %s", i + 1, t))
-  endfor
-
-  var choice: number
-
-  if exists('g:LSPTest') && g:LSPTest && exists('g:LSPTest_CodeActionChoice')
-    # Running the LSP unit-tests. Instead of prompting the user, use the
-    # choice set in LSPTest_CodeActionChoice.
-    choice = g:LSPTest_CodeActionChoice
-  else
-    choice = inputlist(prompt)
-  endif
-
-  if choice < 1 || choice >= prompt->len()
-    return
-  endif
-  var selAction = actions[choice - 1]
-
+export def HandleCodeAction(lspserver: dict<any>, selAction: dict<any>)
   # textDocument/codeAction can return either Command[] or CodeAction[].
   # If it is a CodeAction, it can have either an edit, a command or both.
   # Edits should be executed first.
@@ -50,6 +21,67 @@ export def ApplyCodeAction(lspserver: dict<any>, actions: list<dict<any>>): void
   else
     lspserver.executeCommand(selAction)
   endif
+enddef
+
+def Print(a: any)
+  echo string(a)
+enddef
+
+export def ApplyCodeAction(lspserver: dict<any>, actions: list<dict<any>>): void
+  if actions->empty()
+    # no action can be performed
+    util.WarnMsg('No code action is available')
+    return
+  endif
+
+  var text: list<string> = []
+  var act: dict<any>
+  for i in range(actions->len())
+    act = actions[i]
+    var t: string = act.title->substitute('\r\n', '\\r\\n', 'g')
+    t = t->substitute('\n', '\\n', 'g')
+    text->add(printf(" %d. %s ", i + 1, t))
+  endfor
+
+  var choice: number
+
+  if exists('g:LSPTest') && g:LSPTest && exists('g:LSPTest_CodeActionChoice')
+    # Running the LSP unit-tests. Instead of prompting the user, use the
+    # choice set in LSPTest_CodeActionChoice.
+    choice = g:LSPTest_CodeActionChoice
+  else
+    if opt.lspOptions.usePopupInCodeAction
+      # Use a popup menu to show the code action
+      popup_create(text, {
+        pos: 'botleft',
+        line: 'cursor-1',
+        col: 'cursor',
+        zindex: 1000,
+        cursorline: 1,
+        mapping: 0,
+        wrap: 0,
+        title: 'Code action',
+        callback: (_, id) => {
+          # Invalid item selected or closed the popup
+          if id <= 0 || id > text->len()
+            return
+          endif
+
+          # Do the code action
+          HandleCodeAction(lspserver, actions[id - 1])
+        },
+        filter: 'popup_filter_menu'
+      })
+    else
+      choice = inputlist(["Code action:"] + text)
+    endif
+  endif
+
+  if choice < 1 || choice > text->len()
+    return
+  endif
+
+  HandleCodeAction(lspserver, actions[choice - 1])
 enddef
 
 # vim: tabstop=8 shiftwidth=2 softtabstop=2

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -35,7 +35,9 @@ export var lspOptions: dict<any> = {
   # Make diagnostics show in a popup instead of echoing
   showDiagInPopup: true,
   # Don't print message when a configured language server is missing.
-  ignoreMissingServer: false
+  ignoreMissingServer: false,
+  # Use a floating menu to show the code action menu instead of asking for input
+  usePopupInCodeAction: false
 }
 
 # set LSP options from user provided options

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -36,9 +36,48 @@ export var lspOptions: dict<any> = {
   showDiagInPopup: true,
   # Don't print message when a configured language server is missing.
   ignoreMissingServer: false,
+  # Customize all LSP kinds from the completion popup
+  lspKinds: {},
   # Use a floating menu to show the code action menu instead of asking for input
   usePopupInCodeAction: false
 }
+
+export var defaultLspKinds: dict<string> = {
+  text: 't',
+  method: 'm',
+  function: 'f',
+  constructor: 'C',
+  field: 'F',
+  variable: 'v',
+  class: 'c',
+  interface: 'i',
+  module: 'M',
+  property: 'p',
+  unit: 'u',
+  value: 'V',
+  enum: 'e',
+  keyword: 'k',
+  snippet: 'S',
+  color: 'C',
+  file: 'f',
+  reference: 'r',
+  folder: 'F',
+  enumMember: 'E',
+  constant: 'd',
+  struct: 's',
+  event: 'E',
+  operator: 'o',
+  typeParameter: 'T'
+}
+
+# get a custom LSP kind to use in the completion
+export def GetLspKind(name: string): string
+  if has_key(lspOptions.lspKinds, name)
+    return lspOptions.lspKinds[name]
+  endif
+
+  return defaultLspKinds[name]
+enddef
 
 # set LSP options from user provided options
 export def OptionsSet(opts: dict<any>)

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -36,48 +36,9 @@ export var lspOptions: dict<any> = {
   showDiagInPopup: true,
   # Don't print message when a configured language server is missing.
   ignoreMissingServer: false,
-  # Customize all LSP kinds from the completion popup
-  lspKinds: {},
   # Use a floating menu to show the code action menu instead of asking for input
   usePopupInCodeAction: false
 }
-
-export var defaultLspKinds: dict<string> = {
-  text: 't',
-  method: 'm',
-  function: 'f',
-  constructor: 'C',
-  field: 'F',
-  variable: 'v',
-  class: 'c',
-  interface: 'i',
-  module: 'M',
-  property: 'p',
-  unit: 'u',
-  value: 'V',
-  enum: 'e',
-  keyword: 'k',
-  snippet: 'S',
-  color: 'C',
-  file: 'f',
-  reference: 'r',
-  folder: 'F',
-  enumMember: 'E',
-  constant: 'd',
-  struct: 's',
-  event: 'E',
-  operator: 'o',
-  typeParameter: 'T'
-}
-
-# get a custom LSP kind to use in the completion
-export def GetLspKind(name: string): string
-  if has_key(lspOptions.lspKinds, name)
-    return lspOptions.lspKinds[name]
-  endif
-
-  return defaultLspKinds[name]
-enddef
 
 # set LSP options from user provided options
 export def OptionsSet(opts: dict<any>)

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -267,6 +267,10 @@ showDiagInPopup		When using the |:LspDiagCurrent| command to display
 			popup window to display the message instead of
 			echoing in the status area.  By default this is set to
 			true.
+usePopupInCodeAction    When using the |:LspCodeAction| command to display the
+			code action for the current line, use a popup menu
+			instead of echoing.
+			By default this is set to false.
 ignoreMissingServer	Do not print a missing language server executable.
 			By default this is set to false.
 


### PR DESCRIPTION
Added a option called `usePopupInCodeAction`
If the option is enabled, the command ":LspCodeAction" will use it to show the code action in a popup window
![image](https://user-images.githubusercontent.com/115833146/198162683-d9c145de-e216-4c98-a31d-b6d095415129.png)
