### PR TITLE
Correct HandleCodeAction behavior for CodeAction

### DIFF
--- a/autoload/lsp/codeaction.vim
+++ b/autoload/lsp/codeaction.vim
@@ -10,15 +10,20 @@ export def HandleCodeAction(lspserver: dict<any>, selAction: dict<any>)
   # textDocument/codeAction can return either Command[] or CodeAction[].
   # If it is a CodeAction, it can have either an edit, a command or both.
   # Edits should be executed first.
-  if selAction->has_key('edit') || selAction->has_key('command')
+  # Both Command and CodeAction interfaces has 'command' member
+  # so we should check 'command' type - for Command it will be 'string'
+  if selAction->has_key('edit')
+     || (selAction->has_key('command') && selAction.command->type() == v:t_dict)
+    # selAction is a CodeAction instance, apply edit and command
     if selAction->has_key('edit')
       # apply edit first
       textedit.ApplyWorkspaceEdit(selAction.edit)
     endif
     if selAction->has_key('command')
-      lspserver.executeCommand(selAction)
+      lspserver.executeCommand(selAction.command)
     endif
   else
+    # selAction is a Command instance, apply it directly
     lspserver.executeCommand(selAction)
   endif
 enddef


### PR DESCRIPTION
Both the `CodeAction` and `Command` interfaces contain the `command` member
but these should be handled differently for them. Corrected the
`HandleCodeAction` method to correctly handle these.

Tested with _intelephense_ PHP language server and _clangd_.