### PR TITLE
initializationOptions and doc corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ To register a LSP server, add the following lines to your .vimrc file (use only 
 		\        args: ['--stdio'],
 		\        syncInit: v:true,
 		\        initializationOptions: {
-		\          licenceKey: 'xxxxxxxxxxxxxxx'
+		\          licenceKey: 'absolute path to file with key or key itself'
 		\        }
 		\      }
 		\   ]
    call LspAddServer(lspServers)
 ```
 
-The above lines add the LSP servers for C, C++, Javascript, Typescript, Shell script, Vim script, Go, Rust, Python and Fortran file types.  In addition to the above listed file types, this plugin also supports other file types.
+The above lines add the LSP servers for C, C++, Javascript, Typescript, Shell script, Vim script, Go, Rust, Python, Fortran and PHP file types.  In addition to the above listed file types, this plugin also supports other file types.
 
 To add a LSP server, the following information is needed:
 
@@ -112,6 +112,7 @@ Field|Description
 filetype|One or more file types supported by the LSP server.  This can be a String or a List. To specify multiple multiple file types, use a List.
 path|complete path to the LSP server executable (without any arguments).
 args|a list of command-line arguments passed to the LSP server. Each argument is a separate List item.
+initializationOptions|User provided initialization options. May be of any type. For example the *intelephense* PHP language server accept several options here with the License Key among others. 
 
 The LSP servers are added using the LspAddServer() function. This function accepts a list of LSP servers with the above information.
 
@@ -156,7 +157,7 @@ Command|Description
 :LspHighlight|Highlight all the matches for the keyword under cursor
 :LspHighlightClear|Clear all the matches highlighted by :LspHighlight
 :LspOutline|Show the list of symbols defined in the current file in a separate window.
-:LspFormat|Format the current file using the LSP server.
+:LspFormat|Format the current file using the LSP server. The **shiftwidth** and **expandtab** values set for the current buffer are used when format is applied.
 :{range}LspFormat|Format the specified range of lines.
 :LspIncomingCalls|Display the list of symbols calling the current symbol.
 :LspOutgoingCalls|Display the list of symbols called by the current symbol.

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -467,10 +467,6 @@ export def AddServer(serverList: list<dict<any>>)
 
     var initializationOptions: dict<any> = {}
     if server->has_key('initializationOptions')
-      if server.initializationOptions->type() != v:t_dict
-        util.ErrMsg($'Error: initializationOptions for LSP server {server.initializationOptions} is not a Dictionary')
-        return
-      endif
       initializationOptions = server.initializationOptions
     endif
 

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1463,7 +1463,7 @@ def TagFunc(lspserver: dict<any>, pat: string, flags: string, info: dict<any>): 
   return symbol.TagFunc(lspserver, taglocations, pat)
 enddef
 
-export def NewLspServer(path: string, args: list<string>, isSync: bool, initializationOptions: dict<any>): dict<any>
+export def NewLspServer(path: string, args: list<string>, isSync: bool, initializationOptions: any): dict<any>
   var lspserver: dict<any> = {
     path: path,
     args: args,

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -453,7 +453,9 @@ diagnostic messages, you can add the following line to your .vimrc file:
 			outline window for the various group of symbols.
 
 						*:LspFormat*
-:LspFormat		Format the current file using the LSP server.
+:LspFormat		Format the current file using the LSP server. The
+			*shiftwidth* and *expandtab* values set for the current
+			buffer are used when format is applied.
 
 :{range}LspFormat	Format the specified range of lines in the current
 			file using the LSP server.


### PR DESCRIPTION
* Corrected `initializationOptions` field type. According to specification this should be of type `LSPAny` - so `any` is used
* Corrected `PHP` language server configuration section
* Added description of the `initializationOptions` field
* Added hint on `LspFormat` command since it is not obvious which indentation options are used and how indentation may be controlled