### PR TITLE
feat: make workspace/workspaceFolders really work and correct sendResponse func

### DIFF
--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -124,11 +124,11 @@ def ProcessWorkspaceFoldersReq(lspserver: dict<any>, request: dict<any>)
     lspserver.sendResponse(request, null, {})
     return
   endif
-  if empty(lspserver.workspaceFolders)
+  if lspserver.workspaceFolders->empty()
     lspserver.sendResponse(request, [], {})
   else
     lspserver.sendResponse(request,
-	  \ map(copy(lspserver.workspaceFolders), '{name: v:val->fnamemodify(":t"), uri: util.LspFileToUri(v:val)}'),
+	  \ lspserver.workspaceFolders->copy()->map('{name: v:val->fnamemodify(":t"), uri: util.LspFileToUri(v:val)}'),
 	  \ {})
   endif
 enddef

--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -120,7 +120,17 @@ enddef
 # Request: "workspace/workspaceFolders"
 # Param: none
 def ProcessWorkspaceFoldersReq(lspserver: dict<any>, request: dict<any>)
-  lspserver.sendResponse(request, {}, {})
+  if !lspserver->has_key('workspaceFolders')
+    lspserver.sendResponse(request, null, {})
+    return
+  endif
+  if empty(lspserver.workspaceFolders)
+    lspserver.sendResponse(request, [], {})
+  else
+    lspserver.sendResponse(request,
+	  \ map(copy(lspserver.workspaceFolders), '{name: v:val->fnamemodify(":t"), uri: util.LspFileToUri(v:val)}'),
+	  \ {})
+  endif
 enddef
 
 # process the client/registerCapability LSP server request

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -518,7 +518,7 @@ def CreateNotification(lspserver: dict<any>, notif: string): dict<any>
 enddef
 
 # send a response message to the server
-def SendResponse(lspserver: dict<any>, request: dict<any>, result: dict<any>, error: dict<any>)
+def SendResponse(lspserver: dict<any>, request: dict<any>, result: any, error: dict<any>)
   if (request.id->type() == v:t_string
 	&& (request.id->trim() =~ '[^[:digit:]]\+'
 	    || request.id->trim() == ''))
@@ -528,7 +528,7 @@ def SendResponse(lspserver: dict<any>, request: dict<any>, result: dict<any>, er
   endif
   var resp: dict<any> = lspserver.createResponse(
 	    request.id->type() == v:t_string ? request.id->str2nr() : request.id)
-  if result->type() != v:t_none
+  if empty(error)
     resp->extend({result: result})
   else
     resp->extend({error: error})

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -528,7 +528,7 @@ def SendResponse(lspserver: dict<any>, request: dict<any>, result: any, error: d
   endif
   var resp: dict<any> = lspserver.createResponse(
 	    request.id->type() == v:t_string ? request.id->str2nr() : request.id)
-  if empty(error)
+  if error->empty()
     resp->extend({result: result})
   else
     resp->extend({error: error})


### PR DESCRIPTION
fix issue found at bash lsp server https://github.com/bash-lsp/bash-language-server/pull/535

but `workspace/workspaceFolders`  method was not really worked, 
and `sendResponse()` code logic of judge `errer` and `result` type was wrong.

this pr is trying to address and fix that.

Signed-off-by: shane.xb.qian <shane.qian@foxmail.com>