### PR TITLE
Sort the diagnostics by line number when populating the location-list

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -164,7 +164,7 @@ def DiagsUpdateLocList(lspserver: dict<any>, bnr: number): bool
   var qflist: list<dict<any>> = []
   var text: string
 
-  for [lnum, diag] in lspserver.diagsMap[bnr]->items()
+  for [lnum, diag] in lspserver.diagsMap[bnr]->items()->sort((a, b) => a[0]->str2nr() - b[0]->str2nr())
     text = diag.message->substitute("\n\\+", "\n", 'g')
     qflist->add({filename: fname,
 		    lnum: diag.range.start.line + 1,


### PR DESCRIPTION
The function `items({dict})` returns a list in arbitrary order, and it would be nice that the errors are sorted by how the occur in the source file.