### PR TITLE
Support partially typing the omni completed keyword

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -273,9 +273,12 @@ def g:LspOmniFunc(findstart: number, base: string): any
     # locate the start of the word
     var line = getline('.')
     var start = charcol('.') - 1
+    var keyword: string = ''
     while start > 0 && line[start - 1] =~ '\k'
+      keyword = line[start - 1] .. keyword
       start -= 1
     endwhile
+    lspserver.omniCompleteKeyword = keyword
     return start
   else
     # Wait for the list of matches from the LSP server
@@ -289,7 +292,7 @@ def g:LspOmniFunc(findstart: number, base: string): any
     endwhile
 
     var res: list<dict<any>> = lspserver.completeItems
-    return res->empty() ? v:none : res
+    return res->empty() ? v:none : res->filter((i, v) => v.word =~# '^' .. lspserver.omniCompleteKeyword)
   endif
 enddef
 


### PR DESCRIPTION
Currently when using:

    call LspOptionsSet(#{ autoComplete: v:false })

Omni completion is set, but the partially typed word isn't respected when completing, consider the following:

    $ cat a.c
    int foo = 1;
    int frog = 1;
    int bar = 1;
    int main() {
      int a = f|
    }

Cursor is `|` typing `<C-x><C-o>` the list will contain all three integers: `foo`, `frog`, and `bar`. I would expect only `foo` and `frog`.

Currently it's really hard to write a test for this, as it's not possible to change the "autoComplete" option after the buffer have been initialized, as autocmds and vim options are being set in `BufferInit`.

I think one solution to this problem would be to refactor the current code, to internally react to autocmds when the options have been changed. Alternative the default for the tests should to disable the "autoComplete" option, or another test file should be created with "autoComplete" disabled.

In any case then this PR tries to address only showing the relevant omni completion suggestions.