### PR TITLE
Remove early bailout check

### DIFF
--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -7,9 +7,6 @@ vim9script
 
 # Language Server Protocol (LSP) plugin for vim
 
-if exists('g:loaded_lsp')
-  finish
-endif
 g:loaded_lsp = 1
 
 import autoload '../autoload/lsp/options.vim'


### PR DESCRIPTION
This kind of bailout does not work with vim9 without `vim9script noclear`. See `:h vim9-reload`.

Fixes: #122