### PR TITLE
 Use tab and select first match in completion #127

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -425,16 +425,23 @@ enddef
 export def BufferInit(lspserver: dict<any>, bnr: number, ftype: string)
   # set options for insert mode completion
   if opt.lspOptions.autoComplete
+    var noSel = opt.lspOptions.noSelInCompletion ? ',noselect' : ''
+
     if lspserver.completionLazyDoc
-      setbufvar(bnr, '&completeopt', 'menuone,popuphidden,noinsert,noselect')
+      setbufvar(bnr, '&completeopt', 'menuone,popuphidden,noinsert' .. noSel)
       setbufvar(bnr, '&completepopup', 'width:80,highlight:Pmenu,align:item,border:off')
     else
-      setbufvar(bnr, '&completeopt', 'menuone,popup,noinsert,noselect')
+      setbufvar(bnr, '&completeopt', 'menuone,popup,noinsert' .. noSel)
       setbufvar(bnr, '&completepopup', 'border:off')
     endif
     # <Enter> in insert mode stops completion and inserts a <Enter>
     if !opt.lspOptions.noNewlineInCompletion
       inoremap <expr> <buffer> <CR> pumvisible() ? "\<C-Y>\<CR>" : "\<CR>"
+    endif
+
+	# <Tab> in insert mode confirms selected item in completion list
+    if opt.lspOptions.useTabInCompletion
+      inoremap <expr> <buffer> <Tab> pumvisible() ? "\<C-Y>" : "\<Tab>"
     endif
   else
     if LspOmniComplEnabled(ftype)

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -23,6 +23,8 @@ export var lspOptions: dict<any> = {
   keepFocusInReferences: false,
   # Suppress adding a new line on completion selection with <CR>
   noNewlineInCompletion: false,
+  # Remove selection on the first item in the completion list.
+  noSelInCompletion: true,
   # Outline window size
   outlineWinSize: 20,
   # Open outline window on right side
@@ -38,6 +40,8 @@ export var lspOptions: dict<any> = {
   ignoreMissingServer: false,
   # Use a floating menu to show the code action menu instead of asking for input
   usePopupInCodeAction: false,
+  # Use tab to confirm the selected item in the completion list
+  useTabInCompletion: false,
   # enable snippet completion support
   snippetSupport: false,
   # enable inlay hints

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -280,6 +280,8 @@ noDiagHoverOnLine	Suppress diagnostic hover from appearing when
 noNewlineInCompletion	Suppress adding a new line on completion selection
 			with <CR>.
 			By default this is set to false.
+noSelInCompletion	Remove selection on the first item in the completion list.
+			By default this is set to true.
 outlineOnRight		Open the outline window on the right side, by default
 			this is false.
 outlineWinSize		Outline window size, by default this is 20.
@@ -302,6 +304,8 @@ snippetSupport		Enable snippet completion support.  Need a snippet
 usePopupInCodeAction    When using the |:LspCodeAction| command to display the
 			code action for the current line, use a popup menu
 			instead of echoing.
+			By default this is set to false.
+useTabInCompletion	Using tab to confirm the selected item in the completion list.
 			By default this is set to false.
 
 For example, to disable the automatic placement of signs for the LSP


### PR DESCRIPTION
It can be enabled through LspOptionsSet (It really should be named LspSetOptions)

```
call LspOptionsSet({
	ignoreMissingServer: true,
	noNewlineInCompletion: true,
	noSelInCompletion: false,
	useTabInCompletion: true,
})
```