### PR TITLE
fix: Use character position in TagFunc

### DIFF
--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -468,7 +468,7 @@ export def TagFunc(lspserver: dict<any>,
     var tagitem = {}
     tagitem.name = pat
     tagitem.filename = util.LspUriToFile(tagloc.uri)
-    tagitem.cmd = (tagloc.range.start.line + 1)->string()
+    tagitem.cmd = printf("/\\%%%dl\\%%%dc", tagloc.range.start.line + 1, tagloc.range.start.character + 1)
     retval->add(tagitem)
   endfor
 

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -468,7 +468,7 @@ export def TagFunc(lspserver: dict<any>,
     var tagitem = {}
     tagitem.name = pat
     tagitem.filename = util.LspUriToFile(tagloc.uri)
-    tagitem.cmd = printf("/\\%%%dl\\%%%dc", tagloc.range.start.line + 1, tagloc.range.start.character + 1)
+    tagitem.cmd = $"/\\%{tagloc.range.start.line + 1}l\\%{tagloc.range.start.character + 1}c"
     retval->add(tagitem)
   endfor
 


### PR DESCRIPTION
While using `lsp#lsp#TagFunc`, `CTRL-]` jumps to proper line, but not the proper column. This PR makes it jump to proper column using the LSP character position.