### PR TITLE
Add support for "customNotificationHandlers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ To use the plugin features with a particular file type(s), you need to first reg
 
 To register a LSP server, add the following lines to your .vimrc file (use only the LSP servers that you need from the below list).  If you used [vim-plug](https://github.com/junegunn/vim-plug) to install the LSP plugin, the steps are described later in this section.
 ```
+   function! TypeScriptCustomNotificationHandler(lspserver, reply) abort
+     echom printf("TypeScript Version = %s", reply.params.version)
+   endfunction
    let lspServers = [
 		\     #{
 		\        filetype: ['c', 'cpp'],
@@ -59,6 +62,9 @@ To register a LSP server, add the following lines to your .vimrc file (use only 
 		\	 filetype: ['javascript', 'typescript'],
 		\	 path: '/usr/local/bin/typescript-language-server',
 		\	 args: ['--stdio']
+		\	 customNotificationHandlers: {
+		\	   '$/typescriptVersion': function('TypeScriptCustomNotificationHandler')
+		\	 }
 		\      },
 		\     #{
 		\	 filetype: 'sh',
@@ -115,6 +121,7 @@ filetype|One or more file types supported by the LSP server.  This can be a Stri
 path|complete path to the LSP server executable (without any arguments).
 args|a list of command-line arguments passed to the LSP server. Each argument is a separate List item.
 initializationOptions|User provided initialization options. May be of any type. For example the *intelephense* PHP language server accept several options here with the License Key among others. 
+customNotificationHandlers|A dictionary of notifications and functions that can be specified to add support for custom language server notifications.
 
 The LSP servers are added using the LspAddServer() function. This function accepts a list of LSP servers with the above information.
 

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -429,6 +429,11 @@ export def AddServer(serverList: list<dict<any>>)
       initializationOptions = server.initializationOptions
     endif
 
+    var customNotificationHandlers: dict<func> = {}
+    if server->has_key('customNotificationHandlers')
+      customNotificationHandlers = server.customNotificationHandlers
+    endif
+
     if server.omnicompl->type() != v:t_bool
       util.ErrMsg($'Error: Setting of omnicompl {server.omnicompl} is not a Boolean')
       return
@@ -441,7 +446,8 @@ export def AddServer(serverList: list<dict<any>>)
     var lspserver: dict<any> = lserver.NewLspServer(server.path,
 						    args,
 						    server.syncInit,
-						    initializationOptions)
+						    initializationOptions,
+						    customNotificationHandlers)
 
     var ftypes = server.filetype
     if ftypes->type() == v:t_string

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1589,12 +1589,13 @@ def TagFunc(lspserver: dict<any>, pat: string, flags: string, info: dict<any>): 
   return symbol.TagFunc(lspserver, taglocations, pat)
 enddef
 
-export def NewLspServer(path: string, args: list<string>, isSync: bool, initializationOptions: any): dict<any>
+export def NewLspServer(path: string, args: list<string>, isSync: bool, initializationOptions: any, customNotificationHandlers: dict<func>): dict<any>
   var lspserver: dict<any> = {
     path: path,
     args: args,
     syncInit: isSync,
     initializationOptions: initializationOptions,
+    customNotificationHandlers: customNotificationHandlers,
     running: false,
     ready: false,
     job: v:none,

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -220,6 +220,12 @@ To add a language server, the following information is needed:
 			or useful for initialization. Those can be provided in
 			this dictionary and if present will be transmitted to
 			the lsp server.
+	customNotificationHandlers
+			(Optional) some lsp servers (e.g.
+			typescript-language-server) will send additional
+			notifications which you might want to silence or handle.
+			The provided notification handlers will be called with a
+			reference to the 'lspserver' and the 'reply'.
 	omnicompl	(Optional) a boolean value that enables (true)
 			or disables (false) omni-completion for this file
 			types. By default this is set to 'v:true'.


### PR DESCRIPTION
We need to discuss all the details, currently this MR adds a new property to the "AddServer" dictionary, which when provided will extend and override existing notification handlers.

1. Does it make sense to override the existing notification handlers, or should it only be possible to provide new?
2. Does it make sense to "leak" the internal API `(lspserver, reply)`? Or should only `reply.params` be send?