### PR TITLE
Hide disabled code actions

### DIFF
--- a/autoload/lsp/codeaction.vim
+++ b/autoload/lsp/codeaction.vim
@@ -43,7 +43,13 @@ export def HandleCodeAction(lspserver: dict<any>, selAction: dict<any>)
   endif
 enddef
 
-export def ApplyCodeAction(lspserver: dict<any>, actions: list<dict<any>>): void
+export def ApplyCodeAction(lspserver: dict<any>, actionlist: list<dict<any>>): void
+  var actions = actionlist
+
+  if opt.lspOptions.hideDisabledCodeActions
+    actions = actions->filter((ix, act) => !act->has_key('disabled'))
+  endif
+
   if actions->empty()
     # no action can be performed
     util.WarnMsg('No code action is available')

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -43,7 +43,9 @@ export var lspOptions: dict<any> = {
   # enable snippet completion support
   snippetSupport: false,
   # enable inlay hints
-  showInlayHints: false
+  showInlayHints: false,
+  # hide disabled code actions
+  hideDisabledCodeActions: false
 }
 
 # set the LSP plugin options from the user provided option values

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -282,6 +282,7 @@ diagLineHL		Highlight used for diagnostic line.
 echoSignature		In insert mode, echo the current symbol signature
 			instead of showing it in a popup. By default this is
 			set to false.
+hideDisabledCodeActions Hide all disabled code actions
 ignoreMissingServer	Do not print a missing language server executable.
 			By default this is set to false.
 keepFocusInReferences	Focus on the location list window after

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -208,6 +208,8 @@ Shell script, Vim script and PHP file types: >
 <
 To add a language server, the following information is needed:
 
+	path		complete path to the language server executable
+			(without any arguments).
 	args		a list of command-line arguments passed to the
 			language server. Each argument is a separate List
 			item.
@@ -220,6 +222,9 @@ To add a language server, the following information is needed:
 			or useful for initialization. Those can be provided in
 			this dictionary and if present will be transmitted to
 			the lsp server.
+
+Aditionally the following configurations can be made:
+
 	customNotificationHandlers
 			(Optional) some lsp servers (e.g.
 			typescript-language-server) will send additional
@@ -229,8 +234,6 @@ To add a language server, the following information is needed:
 	omnicompl	(Optional) a boolean value that enables (true)
 			or disables (false) omni-completion for this file
 			types. By default this is set to 'v:true'.
-	path		complete path to the language server executable
-			(without any arguments).
 	syncInit        (Optional) for language servers (e.g. rust analyzer,
 			gopls, etc.) that take time to initialize and reply to
 			a 'initialize' request message this should be set to
@@ -273,6 +276,9 @@ autoHighlightDiags	Automatically place signs on the lines with a
 autoPopulateDiags	Automatically populate the location list with
 			diagnostics from the language server. By default this
 			is set to false.
+diagLineHL		Highlight used for diagnostic line.
+			By default uses `Cursor`.
+			Use `NONE` to disable.
 echoSignature		In insert mode, echo the current symbol signature
 			instead of showing it in a popup. By default this is
 			set to false.
@@ -283,9 +289,6 @@ keepFocusInReferences	Focus on the location list window after
 noDiagHoverOnLine	Suppress diagnostic hover from appearing when
 			the mouse is over the line instead of the signature.
 			By default this is set to true.
-diagLineHL		Highlight used for diagnostic line.
-			By default uses `Cursor`.
-			Use `NONE` to disable.
 noNewlineInCompletion	Suppress adding a new line on completion selection
 			with <CR>.
 			By default this is set to false.


### PR DESCRIPTION
As of 3.16.0 of the [specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction) a code action can contain a `disabled` object, sniff on this object and remove disabled code actions if the `hideDisabledCodeActions` option is set.