### PR TITLE
Respect "isIncomplete" when filtering completion items

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -125,9 +125,10 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
       # snippet completion.  Needs a snippet plugin to expand the snippet.
       # Remove all the snippet placeholders
       d.word = MakeValidWord(d.word)
-    else
+    elseif !lspserver.completeItemsIsIncomplete
       # plain text completion.  If the completion item text doesn't start with
       # the current (case ignored) keyword prefix, skip it.
+      # Don't attempt to filter on the items, when "isIncomplete" is set
       if prefix != '' && d.word->tolower()->stridx(prefix) != 0
 	continue
       endif

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -78,11 +78,14 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
     return
   endif
 
+  lspserver.completeItemsIsIncomplete = false
+
   var items: list<dict<any>>
   if cItems->type() == v:t_list
     items = cItems
   else
     items = cItems.items
+    lspserver.completeItemsIsIncomplete = cItems.isIncomplete
   endif
 
   # Get the keyword prefix before the current cursor column.
@@ -301,6 +304,12 @@ def g:LspOmniFunc(findstart: number, base: string): any
     endwhile
 
     var res: list<dict<any>> = lspserver.completeItems
+
+    # Don't attempt to filter on the items, when "isIncomplete" is set
+    if lspserver.completeItemsIsIncomplete
+      return res->empty() ? v:none : res
+    endif
+
     return res->empty() ? v:none : res->filter((i, v) => v.word =~# '^' .. lspserver.omniCompleteKeyword)
   endif
 enddef


### PR DESCRIPTION
The specifications states:

> for speed clients should be able to filter an already received
> completion list if the user continues typing. Servers can opt out of
> this using a CompletionList and mark it as isIncomplete

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion

Please see attached video: https://asciinema.org/a/4pGB1vszSpaXQp0SDKfGIhozI

Closes #160 , #164