### PR TITLE
Add support for multiple diagnostics on the same line

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -205,14 +205,22 @@ def g:LspDiagExpr(): any
     return ''
   endif
 
-  var diagInfo: dict<any> = lspserver.getDiagByLine(v:beval_bufnr,
-								v:beval_lnum)
-  if diagInfo->empty()
+  var diagsInfo: list<dict<any>> = lspserver.getDiagsByLine(
+    v:beval_bufnr,
+    v:beval_lnum
+  )
+  if diagsInfo->empty()
     # No diagnostic for the current cursor location
     return ''
   endif
 
-  return diagInfo.message->split("\n")
+  # Include all diagnostics from the current line in the message
+  var message: list<string> = []
+  for diag in diagsInfo
+    message->extend(diag.message->split("\n"))
+  endfor
+
+  return message
 enddef
 
 # Called after leaving insert mode. Used to process diag messages (if any)

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1371,10 +1371,8 @@ def CodeAction(lspserver: dict<any>, fname_arg: string, line1: number,
   params->extend({textDocument: {uri: util.LspFileToUri(fname)}, range: r})
   var d: list<dict<any>> = []
   for lnum in range(line1, line2)
-    var diagInfo: dict<any> = diag.GetDiagByLine(lspserver, bnr, lnum)
-    if !diagInfo->empty()
-      d->add(diagInfo)
-    endif
+    var diagsInfo: list<dict<any>> = diag.GetDiagsByLine(lspserver, bnr, lnum)
+    d->extend(diagsInfo)
   endfor
   params->extend({context: {diagnostics: d, triggerKind: 1}})
 
@@ -1665,7 +1663,8 @@ export def NewLspServer(path: string, args: list<string>, isSync: bool, initiali
     processNotif: function(handlers.ProcessNotif, [lspserver]),
     processRequest: function(handlers.ProcessRequest, [lspserver]),
     processMessages: function(handlers.ProcessMessages, [lspserver]),
-    getDiagByLine: function(diag.GetDiagByLine, [lspserver]),
+    getDiagByPos: function(diag.GetDiagByPos, [lspserver]),
+    getDiagsByLine: function(diag.GetDiagsByLine, [lspserver]),
     textdocDidOpen: function(TextdocDidOpen, [lspserver]),
     textdocDidClose: function(TextdocDidClose, [lspserver]),
     textdocDidChange: function(TextdocDidChange, [lspserver]),

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -10,7 +10,7 @@ fi
 
 VIM_CMD="$VIMPRG -u NONE -U NONE -i NONE --noplugin -N --not-a-term"
 
-TESTS="clangd_tests.vim"
+TESTS="tsserver_tests.vim clangd_tests.vim"
 
 for testfile in $TESTS
 do
@@ -24,8 +24,7 @@ do
 
     cat results.txt
 
-    grep -w FAIL results.txt >/dev/null 2>&1
-    if [ $? -eq 0 ]; then
+    if grep -qw FAIL results.txt; then
       echo "ERROR: Some test(s) in $testfile failed."
       exit 3
     fi

--- a/test/runner.vim
+++ b/test/runner.vim
@@ -84,7 +84,7 @@ endfunc
 # Wait for diagnostic messages from the LSP server
 def g:WaitForDiags(errCount: number)
   var retries = 0
-  while retries < 30
+  while retries < 150
     var d = lsp#lsp#ErrorCount()
     if d.Error == errCount
       break

--- a/test/tsserver_tests.vim
+++ b/test/tsserver_tests.vim
@@ -18,11 +18,11 @@ def g:Test_LspDiag()
 
   # This tests that two diagnostics can be on the same line
   var lines: list<string> = [
-    'export obj = {',
-    '  foo: 1,',
-    '  bar: 2,',
-    '  baz: 3',
-    '}'
+    '  export obj = {',
+    '    foo: 1,',
+    '    bar: 2,',
+    '    baz: 3',
+    '  }'
   ]
 
   setline(1, lines)
@@ -34,26 +34,39 @@ def g:Test_LspDiag()
   assert_equal('quickfix', getwinvar(winnr('$'), '&buftype'))
   assert_equal(bnr, qfl[0].bufnr)
   assert_equal(2, qfl->len())
-  assert_equal([1, 1, 'E'], [qfl[0].lnum, qfl[0].col, qfl[0].type])
-  assert_equal([1, 8, 'E'], [qfl[1].lnum, qfl[1].col, qfl[1].type])
+  assert_equal([1, 3, 'E'], [qfl[0].lnum, qfl[0].col, qfl[0].type])
+  assert_equal([1, 10, 'E'], [qfl[1].lnum, qfl[1].col, qfl[1].type])
   close
 
   :sleep 100m
   cursor(5, 1)
   assert_equal('', execute('LspDiagPrev'))
-  assert_equal([1, 8], [line('.'), col('.')])
+  assert_equal([1, 10], [line('.'), col('.')])
 
   assert_equal('', execute('LspDiagPrev'))
-  assert_equal([1, 1], [line('.'), col('.')])
+  assert_equal([1, 3], [line('.'), col('.')])
 
   var output = execute('LspDiagPrev')->split("\n")
   assert_equal('Error: No more diagnostics found', output[0])
 
   cursor(5, 1)
   assert_equal('', execute('LspDiagFirst'))
-  assert_equal([1, 1], [line('.'), col('.')])
+  assert_equal([1, 3], [line('.'), col('.')])
   assert_equal('', execute('LspDiagNext'))
-  assert_equal([1, 8], [line('.'), col('.')])
+  assert_equal([1, 10], [line('.'), col('.')])
+
+  g:LspOptionsSet({showDiagInPopup: false})
+  for i in range(1, 3)
+    cursor(1, i)
+    output = execute('LspDiagCurrent')->split('\n')
+    assert_equal('Declaration or statement expected.', output[0])
+  endfor
+  for i in range(4, 16)
+    cursor(1, i)
+    output = execute('LspDiagCurrent')->split('\n')
+    assert_equal('Cannot find name ''obj''.', output[0])
+  endfor
+  g:LspOptionsSet({showDiagInPopup: true})
 
   :%bw!
 enddef

--- a/test/tsserver_tests.vim
+++ b/test/tsserver_tests.vim
@@ -4,7 +4,7 @@ vim9script
 var lspServers = [{
       filetype: ['typescript', 'javascript'],
       path: exepath('typescript-language-server'),
-      args: ['--stdio', '--tsserver-path=' .. exepath('tsserver')]
+      args: ['--stdio']
   }]
 call LspAddServer(lspServers)
 echomsg systemlist($'{lspServers[0].path} --version')


### PR DESCRIPTION
Sometimes multiple errors can occur on the same line, for instance, the following TypeScript code includes two errors:

```typescript
export obj = {
	foo: 1,
	bar: 2,
	baz: 3
}
```

```
a.ts|1 col 1 error| Declaration or statement expected.          
a.ts|1 col 8 error| Cannot find name 'obj'.
```

But only the last one is shown.

This PR adds support for having multiple diagnostics on the same line.
