### PR TITLE
Hydrate loclist when multiple locations is replied from textDocument/definition, et al

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -900,8 +900,24 @@ def GotoSymbolLoc(lspserver: dict<any>, msg: string, peekSymbol: bool,
     return
   endif
 
+  var title: string = ''
+  if msg ==# 'textDocument/declaration'
+    title = 'Declarations'
+  elseif msg ==# 'textDocument/typeDefinition'
+    title = 'Type Definitions'
+  elseif msg ==# 'textDocument/implementation'
+    title = 'Implementations'
+  else
+    title = 'Definitions'
+  endif
+
   var location: dict<any>
   if reply.result->type() == v:t_list
+    if reply.result->len() > 1
+      symbol.ShowLocations(lspserver, reply.result, peekSymbol, title)
+      return
+    endif
+
     location = reply.result[0]
   else
     location = reply.result

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1064,7 +1064,7 @@ def ShowReferences(lspserver: dict<any>, peek: bool): void
     return
   endif
 
-  symbol.ShowReferences(lspserver, reply.result, peek)
+  symbol.ShowLocations(lspserver, reply.result, peek)
 enddef
 
 # process the 'textDocument/documentHighlight' reply from the LSP server

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1064,7 +1064,7 @@ def ShowReferences(lspserver: dict<any>, peek: bool): void
     return
   endif
 
-  symbol.ShowLocations(lspserver, reply.result, peek)
+  symbol.ShowLocations(lspserver, reply.result, peek, 'Symbol References')
 enddef
 
 # process the 'textDocument/documentHighlight' reply from the LSP server

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -303,7 +303,8 @@ enddef
 
 # Display the locations in a popup menu.  Display the corresponding file in
 # an another popup window.
-def PeekLocations(lspserver: dict<any>, locations: list<dict<any>>)
+def PeekLocations(lspserver: dict<any>, locations: list<dict<any>>,
+                  title: string)
   if lspserver.peekSymbolPopup->winbufnr() != -1
     # If the symbol popup window is already present, close it.
     lspserver.peekSymbolPopup->popup_close()
@@ -330,7 +331,7 @@ def PeekLocations(lspserver: dict<any>, locations: list<dict<any>>)
   endfor
 
   var popupAttrs = {
-    title: 'References',
+    title: title,
     wrap: false,
     pos: 'topleft',
     line: 'cursor+1',
@@ -348,10 +349,10 @@ def PeekLocations(lspserver: dict<any>, locations: list<dict<any>>)
   UpdatePeekFilePopup(lspserver, locations)
 enddef
 
-# Display or peek locations in a loclist
-export def ShowLocations(lspserver: dict<any>, locations: list<dict<any>>, peekSymbol: bool)
+export def ShowLocations(lspserver: dict<any>, locations: list<dict<any>>,
+                         peekSymbol: bool, title: string)
   if peekSymbol
-    PeekLocations(lspserver, locations)
+    PeekLocations(lspserver, locations, title)
     return
   endif
 
@@ -375,7 +376,7 @@ export def ShowLocations(lspserver: dict<any>, locations: list<dict<any>>, peekS
   endfor
 
   var save_winid = win_getid()
-  setloclist(0, [], ' ', {title: 'Symbol Reference', items: qflist})
+  setloclist(0, [], ' ', {title: title, items: qflist})
   var mods: string = ''
   exe $'{mods} lopen'
   if !opt.lspOptions.keepFocusInReferences

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -403,15 +403,23 @@ can map these commands to keys and make it easier to invoke them.
 
 						*:LspGotoDefinition*
 :LspGotoDefinition	Jumps to the definition of the symbol under the
-			cursor.  If the file is already present in a window,
-			then jumps to that window.  Otherwise, opens the file
-			in a  new window.  If the current buffer is modified
-			and 'hidden' is not set or if the current buffer is a
-			special buffer, then a new window is opened.  If the
-			jump is successful, then the current cursor location
-			is pushed onto the tag stack.  The |CTRL-T| command
-			can be used to go back up the tag stack.  Also the
-			|``| mark is set to the position before the jump.
+			cursor.
+
+			If there are multiple matches, then a location list will
+			be created with the list of locations.
+
+			If there is only one location then the following will
+			apply:
+
+			If the file is already present in a window, then jumps
+			to that window.  Otherwise, opens the file in a new
+			window.  If the current buffer is modified and 'hidden'
+			is not set or if the current buffer is a special buffer,
+			then a new window is opened.  If the jump is successful,
+			then the current cursor location is pushed onto the tag
+			stack.  The |CTRL-T| command can be used to go back up
+			the tag stack.  Also the |``| mark is set to the
+			position before the jump.
 
 			This command supports |:command-modifiers|.  You can
 			use the modifiers to specify whether a new window or

--- a/test/tsserver_tests.vim
+++ b/test/tsserver_tests.vim
@@ -71,6 +71,72 @@ def g:Test_LspDiag()
   :%bw!
 enddef
 
+def g:Test_LspGoto()
+  :silent! edit Xtest.ts
+  sleep 200m
+
+  var lines: list<string> = [
+    'function B(val: number): void;'
+    'function B(val: string): void;',
+    'function B(val: string | number) {',
+    '	console.log(val);',
+    '	return void 0;',
+    '}',
+    'typeof B;',
+    'B(1);',
+    'B("1");'
+  ]
+
+  setline(1, lines)
+  :sleep 1
+
+  cursor(8, 1)
+  assert_equal('', execute('LspGotoDefinition'))
+  assert_equal([1, 10], [line('.'), col('.')])
+
+  cursor(9, 1)
+  assert_equal('', execute('LspGotoDefinition'))
+  assert_equal([2, 10], [line('.'), col('.')])
+
+  cursor(9, 1)
+  assert_equal('', execute('LspGotoDefinition'))
+  assert_equal([2, 10], [line('.'), col('.')])
+
+  cursor(7, 8)
+  assert_equal('', execute('LspGotoDefinition'))
+  sleep 200m
+  var qfl: list<dict<any>> = getloclist(0)
+  assert_equal('quickfix', getwinvar(winnr('$'), '&buftype'))
+  assert_equal(bufnr(), qfl[0].bufnr)
+  assert_equal(3, qfl->len())
+  assert_equal([1, 10, ''], [qfl[0].lnum, qfl[0].col, qfl[0].type])
+  assert_equal([2, 10, ''], [qfl[1].lnum, qfl[1].col, qfl[1].type])
+  assert_equal([3, 10, ''], [qfl[2].lnum, qfl[2].col, qfl[2].type])
+  lclose
+
+  # Opening the preview window with an unsaved buffer displays the "E37: No
+  # write since last change" error message.  To disable this message, mark the
+  # buffer as not modified.
+  setlocal nomodified
+  cursor(7, 8)
+  :LspPeekDefinition
+  sleep 10m
+  var ids = popup_list()
+  assert_equal(2, ids->len())
+  var filePopupAttrs = ids[0]->popup_getoptions()
+  var refPopupAttrs = ids[1]->popup_getoptions()
+  assert_match('Xtest', filePopupAttrs.title)
+  assert_match('Definitions', refPopupAttrs.title)
+  assert_equal(1, line('.', ids[0]))
+  assert_equal(3, line('$', ids[1]))
+  feedkeys("jj\<CR>", 'xt')
+  assert_equal(3, line('.'))
+  assert_equal([], popup_list())
+  popup_clear()
+
+  :%bw!
+enddef
+
 # Start the typescript language server.  Returns true on success and false on
 # failure.
 def g:StartLangServer(): bool


### PR DESCRIPTION
This tries to address the main problem in #171

Bear with me, this is a bit larger PR:

The idea is to re-brand all the ShowReferences functions as generic ShowLocations functions.

By doing that the same core logic can be used for both showing references as well as showing multiple Definitions, TypeDefinitions, Inplementations, etc.

All the re-branded functions also gets support for [`LocationLink`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#locationLink), as these can be  in the reply data from the `textDocument/definition` methods.

Lastly a few tests have been added to the tsserver test file, I think these tests in theory could have been added to the `clangd` test file instead, as there isn't anything `tsserver` specific stuff being tested.