### PR TITLE
Add "completionMatcher" which can be set to "icase", "case" or "fuzzy"

### DIFF
--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -45,7 +45,10 @@ export var lspOptions: dict<any> = {
   # enable inlay hints
   showInlayHints: false,
   # hide disabled code actions
-  hideDisabledCodeActions: false
+  hideDisabledCodeActions: false,
+  # icase | fuzzy | case match for language servers that replies with a full
+  # list of completion items
+  completionMatcher: 'case',
 }
 
 # set the LSP plugin options from the user provided option values

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -282,6 +282,17 @@ diagLineHL		Highlight used for diagnostic line.
 echoSignature		In insert mode, echo the current symbol signature
 			instead of showing it in a popup. By default this is
 			set to false.
+completionMatcher	Enable fuzzy or incase sensitive completion for language
+			servers that replies with a full list of completion
+			items.  Some language servers does completion filtering
+			in the server, while other relies on the client to do
+			the filtering.
+
+			This option only works for language servers that expect
+			the client to filter the completion items.
+
+			Can be either `fuzzy`, `icase` or `case`, default is
+			`case`.
 hideDisabledCodeActions Hide all disabled code actions
 ignoreMissingServer	Do not print a missing language server executable.
 			By default this is set to false.


### PR DESCRIPTION
This only works for language servers which always sends the whole set of completion items to the client, like `tsserver`.

Which means this option wouldn't work for `clangd`.

This also makes it possible to opt-out of the ignore cased completion, which have been implemented in #157 and #167 

See a video of how it works here:

https://asciinema.org/a/ko4hFgnzoMUqSVQlvxI1u8OlS