### PR TITLE
Ignore invalid lnum and column for prop_add

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -111,22 +111,27 @@ def DiagsRefreshSigns(lspserver: dict<any>, bnr: number)
 				lnum: lnum,
 				name: DiagSevToSignName(diag.severity)})
 
-    if opt.lspOptions.highlightDiagInline
-      prop_add(diag.range.start.line + 1,
-		util.GetLineByteFromPos(bnr, diag.range.start) + 1,
-		{end_lnum: diag.range.end.line + 1,
-		  end_col: util.GetLineByteFromPos(bnr, diag.range.end) + 1,
-		  bufnr: bnr,
-		  type: DiagSevToInlineHLName(diag.severity)})
-    endif
+    try
+      if opt.lspOptions.highlightDiagInline
+        prop_add(diag.range.start.line + 1,
+                  util.GetLineByteFromPos(bnr, diag.range.start) + 1,
+                  {end_lnum: diag.range.end.line + 1,
+                    end_col: util.GetLineByteFromPos(bnr, diag.range.end) + 1,
+                    bufnr: bnr,
+                    type: DiagSevToInlineHLName(diag.severity)})
+      endif
 
-    if opt.lspOptions.showDiagWithVirtualText
-      prop_add(lnum, 0, {bufnr: bnr,
-			 type: 'LspDiagVirtualText',
-			 text: $'┌─ {diag.message}',
-			 text_align: 'above',
-			 text_padding_left: diag.range.start.character})
-    endif
+      if opt.lspOptions.showDiagWithVirtualText
+        prop_add(lnum, 0, {bufnr: bnr,
+                           type: 'LspDiagVirtualText',
+                           text: $'┌─ {diag.message}',
+                           text_align: 'above',
+                           text_padding_left: diag.range.start.character})
+      endif
+    catch /E966\|E964/ # Invalid lnum | Invalid col
+      # Diagnostics arrive asynchronous and the document changed while they wore
+      # send. Ignore this as new once will arrive shortly.
+    endtry
   endfor
 
   signs->sign_placelist()


### PR DESCRIPTION
Diagnostics arrive asynchronous and the document might have changed before they reach the client.

This could cause the line number or column to be invalid when the diagnostics arrive.

Ignoring these errors isn't a big deal as new diagnostics will be send by the server shortly. And when there isn't any document changes, the client will be updated ASAP.