### PR TITLE
Inform language servers that we really only supports utf-32

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -438,7 +438,16 @@ def InitServer(lspserver: dict<any>)
       }
     },
     window: {},
-    general: {}
+    general: {
+      # Currently we always send character count as position offset,
+      # which meanas only utf-32 is supported.
+      # Adding utf-16 simply for good mesure, as I'm scared some servers will
+      # give up if they don't support utf-32 only.
+      positionEncodings: ['utf-32', 'utf-16']
+    },
+    # This is the way clangd expects to be informated about supported encodings:
+    # https://clangd.llvm.org/extensions#utf-8-offsets
+    offsetEncoding: ['utf-32', 'utf-16']
   }
 
   # interface 'InitializeParams'

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -347,6 +347,14 @@ def ServerInitReply(lspserver: dict<any>, initResult: dict<any>): void
   var caps: dict<any> = initResult.capabilities
   lspserver.caps = caps
 
+  for [key, val] in initResult->items()
+    if key == 'capabilities'
+      continue
+    endif
+
+    lspserver.caps[$'~additionalInitResult_{key}'] = val
+  endfor
+
   ProcessServerCaps(lspserver, caps)
 
   if opt.lspOptions.autoComplete && caps->has_key('completionProvider')

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -272,6 +272,40 @@ def g:Test_LspDiag()
   :%bw!
 enddef
 
+# Test that the client have been able to configure the server to speak utf-32
+def g:Test_UnicodeColumnCalc()
+  :silent! edit Xtest.c
+  sleep 200m
+  var lines: list<string> =<< trim END
+    int count;
+    int fn(int a)
+    {
+      int 😊😊😊😊;
+      😊😊😊😊 = a;
+
+      int b;
+      b = a;
+      return    count + 1;
+    }
+  END
+  setline(1, lines)
+  :redraw!
+
+  cursor(5, 1) # 😊😊😊😊 = a;
+  search('a')
+  assert_equal([],
+              execute('LspGotoDefinition')->split("\n"))
+  assert_equal([2, 12], [line('.'), col('.')])
+
+  cursor(8, 1) # b = a;
+  search('a')
+  assert_equal([],
+              execute('LspGotoDefinition')->split("\n"))
+  assert_equal([2, 12], [line('.'), col('.')])
+
+  bw!
+enddef
+
 # Test for multiple LSP diagnostics on the same line
 def g:Test_LspDiag_Multi()
   :silent! edit Xtest.c


### PR DESCRIPTION
I think this configures `clangd` to talk utf-32, and also informs other servers that we would like to do the same.

I havn't been able to find any server that can be configured with [`general.positionEncoding`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities) yet, but `clangd` have their own way to be configured which AFAIK works in `clangd14`.