### PR TITLE
Feat/add option to show references in qf

### DIFF
--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -72,6 +72,8 @@ export var lspOptions: dict<any> = {
   diagSignInfoTexthl: 'Pmenu',
   diagSignHintText: 'H>',
   diagSignHintTexthl: 'Question',
+  # ShowReferences in a quickfix list instead of a location list`
+  useQuickfixForLocations: false
 }
 
 # set the LSP plugin options from the user provided option values

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -376,9 +376,17 @@ export def ShowLocations(lspserver: dict<any>, locations: list<dict<any>>,
   endfor
 
   var save_winid = win_getid()
-  setloclist(0, [], ' ', {title: title, items: qflist})
-  var mods: string = ''
-  exe $'{mods} lopen'
+
+  if opt.lspOptions.useQuickfixForLocations
+    setqflist([], ' ', {title: title, items: qflist})
+    var mods: string = ''
+    exe $'{mods} copen'
+  else
+    setloclist(0, [], ' ', {title: title, items: qflist})
+    var mods: string = ''
+    exe $'{mods} lopen'
+  endif
+
   if !opt.lspOptions.keepFocusInReferences
     save_winid->win_gotoid()
   endif

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -326,6 +326,9 @@ echoSignature		|Boolean| option.  In insert mode, echo the current
 			By default this is set to false.
 hideDisabledCodeActions |Boolean| option. Hide all the disabled code actions.
 			By default this is set to false.
+hoverInPreview		|Boolean| option. Show |:LspHover| in a preview window
+			instead of a popup
+			By default this is set to false.
 ignoreMissingServer	|Boolean| option.  Do not print a missing language
 			server executable.  By default this is set to false.
 keepFocusInReferences	|Boolean| option.  Focus on the location list window

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -344,6 +344,9 @@ outlineOnRight		|Boolean| option.  Open the outline window on the
 			right side, by default this is false.
 outlineWinSize		|Number| option.  The size of the symbol Outline
 			window.  By default this is set to 20.
+useQuickfixForLocations	|Boolean| option.  Show |:LspShowReferences| in a
+			quickfix list instead of a location list.
+			By default this is set to false.
 showDiagInPopup		|Boolean| option.  When using the |:LspDiagCurrent|
 			command to display the diagnostic message for the
 			current line, use a popup window to display the
@@ -671,7 +674,13 @@ can map these commands to keys and make it easier to invoke them.
 						*:LspShowReferences*
 :LspShowReferences	Creates a new location list with the list of locations
 			where the symbol under the cursor is referenced and
-			opens the location window.
+			opens the location window.  If you want to show the
+			references in a quickfix list instead of in a location
+			list set >
+
+				call LspOptionsSet({'useQuickfixForLocations': v:true})
+<
+			Set '
 
 :LspShowServerCapabilities			*:LspShowServerCapabilities*
 			Display the list of language server capabilities for

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -163,19 +163,40 @@ def g:Test_LspShowReferences()
   :LspShowReferences
   sleep 100m
   assert_equal('quickfix', getwinvar(winnr('$'), '&buftype'))
-  var qfl: list<dict<any>> = getloclist(0)
-  assert_equal(bnr, qfl[0].bufnr)
+  var loclist: list<dict<any>> = getloclist(0)
+  assert_equal(bnr, loclist[0].bufnr)
+  assert_equal(3, loclist->len())
+  assert_equal([4, 6], [loclist[0].lnum, loclist[0].col])
+  assert_equal([5, 2], [loclist[1].lnum, loclist[1].col])
+  assert_equal([6, 6], [loclist[2].lnum, loclist[2].col])
+  :only
+  cursor(1, 5)
+  :LspShowReferences
+  assert_equal(1, getloclist(0)->len())
+  loclist = getloclist(0)
+  assert_equal([1, 5], [loclist[0].lnum, loclist[0].col])
+  :lclose
+
+  # Test for opening in qf list
+  g:LspOptionsSet({ useQuickfixForLocations: true })
+  cursor(5, 2)
+  :LspShowReferences
+  sleep 100m
+  assert_equal('quickfix', getwinvar(winnr('$'), '&buftype'))
+  var qfl: list<dict<any>> = getqflist()
   assert_equal(3, qfl->len())
+  assert_equal(bufnr(), qfl[0].bufnr)
   assert_equal([4, 6], [qfl[0].lnum, qfl[0].col])
   assert_equal([5, 2], [qfl[1].lnum, qfl[1].col])
   assert_equal([6, 6], [qfl[2].lnum, qfl[2].col])
   :only
   cursor(1, 5)
   :LspShowReferences
-  assert_equal(1, getloclist(0)->len())
-  qfl = getloclist(0)
+  assert_equal(1, getqflist()->len())
+  qfl = getqflist()
   assert_equal([1, 5], [qfl[0].lnum, qfl[0].col])
-  :lclose
+  :cclose
+  g:LspOptionsSet({ useQuickfixForLocations: false })
 
   # Test for LspPeekReferences
 

--- a/test/tsserver_tests.vim
+++ b/test/tsserver_tests.vim
@@ -49,14 +49,28 @@ def g:Test_LspGoto()
   cursor(7, 8)
   assert_equal('', execute('LspGotoDefinition'))
   sleep 200m
-  var qfl: list<dict<any>> = getloclist(0)
+  var loclist: list<dict<any>> = getloclist(0)
   assert_equal('quickfix', getwinvar(winnr('$'), '&buftype'))
-  assert_equal(bufnr(), qfl[0].bufnr)
+  assert_equal(3, loclist->len())
+  assert_equal(bufnr(), loclist[0].bufnr)
+  assert_equal([1, 10, ''], [loclist[0].lnum, loclist[0].col, loclist[0].type])
+  assert_equal([2, 10, ''], [loclist[1].lnum, loclist[1].col, loclist[1].type])
+  assert_equal([3, 10, ''], [loclist[2].lnum, loclist[2].col, loclist[2].type])
+  lclose
+
+  g:LspOptionsSet({ useQuickfixForLocations: true })
+  cursor(7, 8)
+  assert_equal('', execute('LspGotoDefinition'))
+  sleep 200m
+  var qfl: list<dict<any>> = getqflist()
+  assert_equal('quickfix', getwinvar(winnr('$'), '&buftype'))
   assert_equal(3, qfl->len())
+  assert_equal(bufnr(), qfl[0].bufnr)
   assert_equal([1, 10, ''], [qfl[0].lnum, qfl[0].col, qfl[0].type])
   assert_equal([2, 10, ''], [qfl[1].lnum, qfl[1].col, qfl[1].type])
   assert_equal([3, 10, ''], [qfl[2].lnum, qfl[2].col, qfl[2].type])
-  lclose
+  cclose
+  g:LspOptionsSet({ useQuickfixForLocations: false })
 
   # Opening the preview window with an unsaved buffer displays the "E37: No
   # write since last change" error message.  To disable this message, mark the


### PR DESCRIPTION
Add the option "useQuickfixForLocations" to use the quickfix list for locations comming from ":LspShowReferences", ":LspGotoDefinition", etc.