### PR TITLE
Chore/normalize bufferinit

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -407,7 +407,7 @@ enddef
 
 # If the completion popup documentation window displays 'markdown' content,
 # then set the 'filetype' to 'lspgfm'.
-def LspSetFileType()
+def LspSetPopupFileType()
   var item = v:event.completed_item
   if !item->has_key('user_data') || item.user_data->empty()
     return
@@ -471,7 +471,7 @@ def AddAutocmds(lspserver: dict<any>, bnr: number)
   acmds->add({bufnr: bnr,
                  event: 'CompleteChanged',
                  group: 'LSPBufferAutocmds',
-                 cmd: 'LspSetFileType()'})
+                 cmd: 'LspSetPopupFileType()'})
 
   # Execute LSP server initiated text edits after completion
   acmds->add({bufnr: bnr,

--- a/autoload/lsp/inlayhints.vim
+++ b/autoload/lsp/inlayhints.vim
@@ -4,6 +4,7 @@ vim9script
 
 import './util.vim'
 import './buffer.vim' as buf
+import './options.vim' as opt
 
 # Initialize the highlight group and the text property type used for
 # inlay hints.
@@ -103,7 +104,17 @@ def LspInlayHintsUpdateStop()
 enddef
 
 # Do buffer-local initialization for displaying inlay hints
-export def BufferInit(bnr: number)
+export def BufferInit(lspserver: dict<any>, bnr: number)
+  if !lspserver.isInlayHintProvider && !lspserver.isClangdInlayHintsProvider
+    # no support for inley hints
+    return
+  endif
+
+  # Inlays hints are disabled
+  if !opt.lspOptions.showInlayHints
+    return
+  endif
+
   var acmds: list<dict<any>> = []
 
   # Update the inlay hints (if needed) when the cursor is not moved for some

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -300,12 +300,6 @@ def AddBufLocalAutocmds(lspserver: dict<any>, bnr: number): void
 		cmd: 'call LspDocHighlightClear() | call LspDocHighlight()'})
   endif
 
-  # Displaying inlay hints needs the Vim virtual text support.
-  if opt.lspOptions.showInlayHints && (lspserver.isInlayHintProvider
-				|| lspserver.isClangdInlayHintsProvider)
-    inlayhints.BufferInit(bnr)
-  endif
-
   # Show diagnostics on the status line
   if opt.lspOptions.showDiagOnStatusLine
     acmds->add({bufnr: bnr,

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -323,14 +323,13 @@ def BufferInit(bnr: number): void
   # add a listener to track changes to this buffer
   listener_add(Bufchange_listener, bnr)
 
-  completion.BufferInit(lspserver, bnr, ftype)
+  AddBufLocalAutocmds(lspserver, bnr)
 
   setbufvar(bnr, '&balloonexpr', 'g:LspDiagExpr()')
 
-  # initialize signature help
-  signature.SignatureInit(lspserver)
-
-  AddBufLocalAutocmds(lspserver, bnr)
+  completion.BufferInit(lspserver, bnr, ftype)
+  signature.BufferInit(lspserver)
+  inlayhints.BufferInit(lspserver, bnr)
 
   if exists('#User#LspAttached')
     doautocmd <nomodeline> User LspAttached

--- a/autoload/lsp/signature.vim
+++ b/autoload/lsp/signature.vim
@@ -22,11 +22,15 @@ def CloseCurBufSignaturePopup()
 enddef
 
 # Initialize the signature triggers for the current buffer
-export def SignatureInit(lspserver: dict<any>)
-  if !opt.lspOptions.showSignature
-	|| !lspserver.isSignatureHelpProvider
+export def BufferInit(lspserver: dict<any>)
+  if !lspserver.isSignatureHelpProvider
 	|| !lspserver.caps.signatureHelpProvider->has_key('triggerCharacters')
     # no support for signature help
+    return
+  endif
+
+  if !opt.lspOptions.showSignature
+    # Show signature are disabled
     return
   endif
 
@@ -34,6 +38,7 @@ export def SignatureInit(lspserver: dict<any>)
   for ch in lspserver.caps.signatureHelpProvider.triggerCharacters
     exe $"inoremap <buffer> <silent> {ch} {ch}<C-R>=LspShowSignature()<CR>"
   endfor
+
   # close the signature popup when leaving insert mode
   autocmd_add([{bufnr: bufnr(),
 		event: 'InsertLeave',


### PR DESCRIPTION
This MR is an attempt to simplify the code so that each function is called the same, and behave the same way.

Rename "SignatureInit" to "BufferInit" as it works the same as the "BufferInit" functions in inlayhints and completion.

Remove the "completion#AddAutocmds" as the other "BufferInit" functions have the autocmd code within the "BufferInit function.

Move the support logic inside the "inlayhint#BufferInit" function as "signature#BufferInit" have it that way.