### PR TITLE
Add `:LspDiagCurrent!` to _only_ show diags if they are under the cursor

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -555,13 +555,13 @@ export def ShowDiagnostics(): void
 enddef
 
 # Show the diagnostic message for the current line
-export def LspShowCurrentDiag()
+export def LspShowCurrentDiag(atPos: bool)
   var lspserver: dict<any> = buf.CurbufGetServerChecked()
   if lspserver->empty()
     return
   endif
 
-  diag.ShowCurrentDiag(lspserver)
+  diag.ShowCurrentDiag(lspserver, atPos)
 enddef
 
 # Display the diagnostics for the current line in the status line.

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -154,8 +154,8 @@ a list of lanaguge server details in the .vimrc file.
 To register a language server, add the following lines to your .vimrc file
 (use only the language servers that you need from the below list).
 If you used [vim-plug](https://github.com/junegunn/vim-plug) to install the
-LSP plugin, the steps are described later in this section:
->
+LSP plugin, the steps are described later in this section: >
+
    let lspServers = [
 		\     #{
 		\	 filetype: ['javascript', 'typescript'],
@@ -412,7 +412,7 @@ To get a particular option value you can use the following: >
 	echo LspOptionsGet()['autoHighlightDiags']
 <
 ==============================================================================
-5. Commands						*lsp-commands*
+5. Commands					*lsp-commands*
 
 A description of the various commands provided by this plugin is below.  You
 can map these commands to keys and make it easier to invoke them.
@@ -513,6 +513,7 @@ can map these commands to keys and make it easier to invoke them.
 			use the modifiers to specify whether a new window or
 			a new tab page is used and where the window is opened.
 			Example(s): >
+
 			    # Open a horizontally split window
 			    :topleft LspGotoDefinition
 			    # Open a vertically split window
@@ -696,7 +697,6 @@ can map these commands to keys and make it easier to invoke them.
 
 				call LspOptionsSet({'useQuickfixForLocations': v:true})
 <
-			Set '
 
 :LspShowServerCapabilities			*:LspShowServerCapabilities*
 			Display the list of language server capabilities for
@@ -877,8 +877,8 @@ using the |:LspDiagHighlightDisable| command and re-enable them using the
 |:LspDiagHighlightEnable| command.
 
 To disable the automatic placement of signs on the lines with a diagnostic
-message, you can set the 'autoHighlightDiags' option to v:false:
->
+message, you can set the 'autoHighlightDiags' option to v:false: >
+
 	call LspOptionsSet({'autoHighlightDiags': v:false})
 <
 By default the 'autoHighlightDiags' option is set to v:true.
@@ -940,8 +940,8 @@ The |:LspFormat| command can be used to format either the entire file or a
 selected range of lines using the language server.  The 'shiftwidth' and
 'expandtab' values set for the current buffer are used when format is applied.
 
-To format code using the 'gq' command, you can set the 'formatexpr' option:
->
+To format code using the 'gq' command, you can set the 'formatexpr' option: >
+
     setlocal formatexpr=lsp#lsp#FormatExpr()
 <
 ==============================================================================
@@ -997,7 +997,7 @@ LspDiagsUpdated			A |User| autocommand invoked when new
 				has processed the diagnostics.
 
 ==============================================================================
-12. Highlight Groups					*lsp-highlight-groups*
+12. Highlight Groups				*lsp-highlight-groups*
 
 The following highlight groups are used by the LSP plugin.  You can define
 these highlight groups in your .vimrc file before sourcing this plugin to
@@ -1038,19 +1038,17 @@ override them.
 				group.
 
 For example, to override the highlight used for diagnostics virtual text, you
-can use the following:
->
+can use the following: >
+
     highlight LspDiagVirtualText ctermfg=Cyan guifg=Blue
 <
+or >
 
-or
-
->
     highlight link LspDiagLine NONE
     highlight link LspDiagVirtualText WarningMsg
 <
 ==============================================================================
-13. Debugging						*lsp-debug*
+13. Debugging					*lsp-debug*
 
 To debug this plugin, you can log the language server protocol messages sent
 and received by the plugin from the language server.  The following command

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -443,6 +443,14 @@ can map these commands to keys and make it easier to invoke them.
 			the cursor.  Otherwise works exactly like
 			|:LspDiagCurrent|
 
+			To show the current diagnotic under the cursor while
+			moving around the following autocmd can be used: >
+
+			    augroup LspCustom
+			    au!
+			    au CursorMoved * silent! LspDiagCurrent!
+			    augroup END
+<
 						*:LspDiagFirst*
 :LspDiagFirst		Jumps to the location of the first diagnostic message
 			for the current file.

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -439,6 +439,10 @@ can map these commands to keys and make it easier to invoke them.
 			a popup window.  Otherwise the message is displayed in
 			the status message area.
 
+:LspDiagCurrent!	Only display a diagnostic message if it's directly under
+			the cursor.  Otherwise works exactly like
+			|:LspDiagCurrent|
+
 						*:LspDiagFirst*
 :LspDiagFirst		Jumps to the location of the first diagnostic message
 			for the current file.

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -78,7 +78,7 @@ augroup END
 
 # LSP commands
 command! -nargs=? -bar -range LspCodeAction lsp.CodeAction(<line1>, <line2>, <q-args>)
-command! -nargs=0 -bar LspDiagCurrent lsp.LspShowCurrentDiag()
+command! -nargs=0 -bar -bang LspDiagCurrent lsp.LspShowCurrentDiag(<bang>false)
 command! -nargs=0 -bar LspDiagFirst lsp.JumpToDiag('first')
 command! -nargs=0 -bar LspDiagHighlightDisable lsp.DiagHighlightDisable()
 command! -nargs=0 -bar LspDiagHighlightEnable lsp.DiagHighlightEnable()

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -404,6 +404,37 @@ def g:Test_LspDiag_Multi()
   endfor
   g:LspOptionsSet({showDiagInPopup: true})
 
+  # Check for exact diag ":LspDiagCurrent!"
+  g:LspOptionsSet({showDiagInPopup: false})
+  for i in range(1, 4)
+    cursor(1, i)
+    output = execute('LspDiagCurrent!')->split('\n')
+    assert_match('No diagnostic messages found for current line', output[0])
+  endfor
+
+  cursor(1, 5)
+  output = execute('LspDiagCurrent!')->split('\n')
+  assert_match('Incompatible pointer to integer', output[0])
+
+  for i in range(6, 8)
+    cursor(1, i)
+    output = execute('LspDiagCurrent!')->split('\n')
+    assert_match('No diagnostic messages found for current line', output[0])
+  endfor
+
+  for i in range(9, 11)
+    cursor(1, i)
+    output = execute('LspDiagCurrent!')->split('\n')
+    assert_match('Initializer element is not ', output[0])
+  endfor
+  for i in range(12, 12)
+    cursor(1, i)
+    output = execute('LspDiagCurrent!')->split('\n')
+    assert_match('No diagnostic messages found for current line', output[0])
+  endfor
+
+  g:LspOptionsSet({showDiagInPopup: true})
+
   bw!
 enddef
 


### PR DESCRIPTION
Make it possible to show diagnostics directly under the cursor, and not for the current line.

See the difference in this video:

https://asciinema.org/a/TVLSmVSoOjGxUzI5kRPTaMNp6