### PR TITLE
Hide diagnostic popup when ":LspHover" is used

### DIFF
--- a/autoload/lsp/hover.vim
+++ b/autoload/lsp/hover.vim
@@ -74,6 +74,7 @@ export def HoverReply(lspserver: dict<any>, hoverResult: any): void
     exe $'setlocal ft={hoverKind}'
     :wincmd p
   else
+    popup_clear()
     var winid = hoverText->popup_atcursor({moved: 'word',
 					   maxwidth: 80,
 					   border: [0, 1, 0, 1],

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -947,6 +947,8 @@ def g:Test_LspHover()
     void f2(void)
     {
       f1(5);
+      char *z = "z";
+      f1(z);
     }
   END
   setline(1, lines)
@@ -960,7 +962,19 @@ def g:Test_LspHover()
   cursor(7, 1)
   :LspHover
   assert_equal([], popup_list())
+
+  # Show current diagnostic as to open another popup.
+  # Then we can test that LspHover closes all existing popups
+  cursor(10, 6)
+  :LspDiagCurrent
+  assert_equal(1, popup_list()->len())
+  :LspHover
+  assert_equal(1, popup_list()->len())
+  popup_clear()
+
   :%bw!
+
+
 enddef
 
 # Test for :LspShowSignature


### PR DESCRIPTION
This related to the introduction of ":LspDiagCurrent!", Introduced in "be2221b~..4c93f5d", as the hover popup will be below the automatically shown diagnostic popup.

See video:

https://asciinema.org/a/EJlFPVOlp4oU8hqJqOWYntHqg