### PR TITLE
Show error message instead of an empty popup when there are not content for ":LspHover"

### DIFF
--- a/autoload/lsp/hover.vim
+++ b/autoload/lsp/hover.vim
@@ -22,6 +22,10 @@ def GetHoverText(hoverResult: any): list<any>
       return [hoverResult.contents.value->split("\n"), 'lspgfm']
     endif
 
+    util.TraceLog(
+      true,
+      $'{strftime("%m/%d/%y %T")}: Unsupported hover contents kind ({hoverResult.contents.kind})'
+    )
     return ['', '']
   endif
 
@@ -61,6 +65,10 @@ def GetHoverText(hoverResult: any): list<any>
     return [hoverText, 'lspgfm']
   endif
 
+  util.TraceLog(
+    true,
+    $'{strftime("%m/%d/%y %T")}: Unsupported hover reply ({hoverResult})'
+  )
   return ['', '']
 enddef
 

--- a/autoload/lsp/hover.vim
+++ b/autoload/lsp/hover.vim
@@ -5,45 +5,50 @@ vim9script
 import './util.vim'
 import './options.vim' as opt
 
-# process the 'textDocument/hover' reply from the LSP server
-# Result: Hover | null
-export def HoverReply(lspserver: dict<any>, hoverResult: any): void
+# Util used to compute the hoverText from textDocument/hover reply
+def GetHoverText(hoverResult: any): list<any>
   if hoverResult->empty()
-    return
+    return ['', '']
   endif
 
-  var hoverText: list<string>
-  var hoverKind: string
-
+  # MarkupContent
   if hoverResult.contents->type() == v:t_dict
-    if hoverResult.contents->has_key('kind')
-      # MarkupContent
-      if hoverResult.contents.kind == 'plaintext'
-        hoverText = hoverResult.contents.value->split("\n")
-        hoverKind = 'text'
-      elseif hoverResult.contents.kind == 'markdown'
-        hoverText = hoverResult.contents.value->split("\n")
-        hoverKind = 'lspgfm'
-      else
-        util.ErrMsg($'Error: Unsupported hover contents type ({hoverResult.contents.kind})')
-        return
-      endif
-    elseif hoverResult.contents->has_key('value')
-      # MarkedString
-      hoverText->extend([$'``` {hoverResult.contents.language}'])
-      hoverText->extend(hoverResult.contents.value->split("\n"))
-      hoverText->extend(['```'])
-      hoverKind = 'lspgfm'
-    else
-      util.ErrMsg($'Error: Unsupported hover contents ({hoverResult.contents})')
-      return
+      && hoverResult.contents->has_key('kind')
+    if hoverResult.contents.kind == 'plaintext'
+      return [hoverResult.contents.value->split("\n"), 'text']
     endif
-  elseif hoverResult.contents->type() == v:t_list
-    # interface MarkedString[]
+
+    if hoverResult.contents.kind == 'markdown'
+      return [hoverResult.contents.value->split("\n"), 'lspgfm']
+    endif
+
+    return ['', '']
+  endif
+
+  # MarkedString
+  if hoverResult.contents->type() == v:t_dict
+      && hoverResult.contents->has_key('value')
+    return [
+      [$'``` {hoverResult.contents.language}']
+        + hoverResult.contents.value->split("\n")
+        + ['```'],
+      'lspgfm'
+    ]
+  endif
+
+  # MarkedString
+  if hoverResult.contents->type() == v:t_string
+    return [hoverResult.contents->split("\n"), 'lspgfm']
+  endif
+
+  # interface MarkedString[]
+  if hoverResult.contents->type() == v:t_list
+    var hoverText: list<string> = []
     for e in hoverResult.contents
       if !hoverText->empty()
         hoverText->extend(['- - -'])
       endif
+
       if e->type() == v:t_string
         hoverText->extend(e->split("\n"))
       else
@@ -52,14 +57,21 @@ export def HoverReply(lspserver: dict<any>, hoverResult: any): void
         hoverText->extend(['```'])
       endif
     endfor
-    hoverKind = 'lspgfm'
-  elseif hoverResult.contents->type() == v:t_string
-    if hoverResult.contents->empty()
-      return
-    endif
-    hoverText->extend(hoverResult.contents->split("\n"))
-  else
-    util.ErrMsg($'Error: Unsupported hover contents ({hoverResult.contents})')
+
+    return [hoverText, 'lspgfm']
+  endif
+
+  return ['', '']
+enddef
+
+# process the 'textDocument/hover' reply from the LSP server
+# Result: Hover | null
+export def HoverReply(lspserver: dict<any>, hoverResult: any): void
+  var [ hoverText, hoverKind ] = GetHoverText(hoverResult)
+
+  # Nothing to show
+  if hoverText->empty()
+    util.WarnMsg($'No hover messages found for current position')
     return
   endif
 

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -954,13 +954,15 @@ def g:Test_LspHover()
   setline(1, lines)
   g:WaitForServerFileLoad(0)
   cursor(8, 4)
-  :LspHover
+  var output = execute(':LspHover')->split("\n")
+  assert_equal([], output)
   var p: list<number> = popup_list()
   assert_equal(1, p->len())
   assert_equal(['function f1', '', '→ int', 'Parameters:', '- int a', '', 'int f1(int a)'], getbufline(winbufnr(p[0]), 1, '$'))
   popup_close(p[0])
   cursor(7, 1)
-  :LspHover
+  output = execute(':LspHover')->split("\n")
+  assert_equal('No hover messages found for current position', output[0])
   assert_equal([], popup_list())
 
   # Show current diagnostic as to open another popup.


### PR DESCRIPTION
Instead of showing an empty popup an error is shown when there is no hover:

I'm aware that some language servers already replies in a way that would result in no poup, but not the typescript-language-server.

This PR attempts to normalize the behavior across all language servers, by moving the hoverText calculation to its own function and draw the error if that function didn't return any hoverText.

Before | After
-------|-------
<img width="548" alt="Before" src="https://user-images.githubusercontent.com/3134030/229574396-d0140635-18d3-4433-838c-32215c161d4a.png">|<img width="629" alt="After" src="https://user-images.githubusercontent.com/3134030/229574391-8a99ac30-b686-4199-ad85-a7d5f5bce04b.png">



See video for example:

https://asciinema.org/a/S7urffOWgXtq8bwMXuJOPwz2W