### PR TITLE
Don't setup completion for servers that doesn't support it

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -479,6 +479,10 @@ enddef
 
 # Initialize buffer-local completion options and autocmds
 export def BufferInit(lspserver: dict<any>, bnr: number, ftype: string)
+  if !lspserver.isCompletionProvider
+    # no support for completion
+    return
+  endif
 
   # buffer-local autocmds for completion
   var acmds: list<dict<any>> = []


### PR DESCRIPTION
There are no reason to add completion related autocmds, omnifunc etc, for servers that doesn't support it.

This was inspired by #219 