### PR TITLE
Use cwd as rootUri and initial workspaceFolder for files within cwd

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -153,14 +153,14 @@ def InitServer(lspserver: dict<any>, bnr: number)
       }
 
   # Compute the rootpath (based on the directory of the buffer)
-  var bufDir = bnr->bufname()->fnamemodify(':p:h')
   var rootPath = ''
   var rootSearchFiles = lspserver.rootSearchFiles
   if !rootSearchFiles->empty()
+    var bufDir = bnr->bufname()->fnamemodify(':p:h')
     rootPath = util.FindNearestRootDir(bufDir, rootSearchFiles)
   endif
   if rootPath == ''
-    rootPath = bufDir
+    rootPath = getcwd()
   endif
 
   lspserver.workspaceFolders = [rootPath]

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -155,12 +155,22 @@ def InitServer(lspserver: dict<any>, bnr: number)
   # Compute the rootpath (based on the directory of the buffer)
   var rootPath = ''
   var rootSearchFiles = lspserver.rootSearchFiles
+  var bufDir = bnr->bufname()->fnamemodify(':p:h')
   if !rootSearchFiles->empty()
-    var bufDir = bnr->bufname()->fnamemodify(':p:h')
     rootPath = util.FindNearestRootDir(bufDir, rootSearchFiles)
   endif
   if rootPath == ''
-    rootPath = getcwd()
+    var cwd = getcwd()
+
+    # bufDir is within cwd
+    var bufDirPrefix = bufDir[0 : cwd->strcharlen() - 1]
+    if &fileignorecase
+        ? bufDirPrefix ==? cwd
+        : bufDirPrefix ==# cwd
+      rootPath = cwd
+    else
+      rootPath = bufDir
+    endif
   endif
 
   lspserver.workspaceFolders = [rootPath]

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -270,8 +270,10 @@ To add a language server, the following information is needed:
 			multiple directories are found, then the directory
 			closest to the directory of the current buffer is used
 			as the workspace root.  If this parameter is not
-			specified or the files are not found, then the
-			current working directory is used as the workspace root.
+			specified or the files are not found, then the current
+			working directory is used as the workspace root for
+			decendent files, for any other files the parent
+			directory of the file is used.
 
 Aditionally the following configurations can be made:
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -271,8 +271,7 @@ To add a language server, the following information is needed:
 			closest to the directory of the current buffer is used
 			as the workspace root.  If this parameter is not
 			specified or the files are not found, then the
-			directory of the current buffer is used as the
-			workspace root.
+			current working directory is used as the workspace root.
 
 Aditionally the following configurations can be made:
 


### PR DESCRIPTION
- Use the CWD as the "rootUri" and initial "workspaceFolder"
- Use the parent directory for files not a descendent of the cwd

I think this makes more sense as a default, and it's also almost backward compatible for before ca7f26773bf4348d956e16d3d9dba82ca87c180c

It's hard to add a test as we reuse the LSP for every test.