### PR TITLE
Make it possible to have multiple servers registred for a given filetype

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -162,7 +162,7 @@ export def ShowServer()
     return
   endif
 
-  var msg = $"LSP server '{lspserver.path}' is "
+  var msg = $"LSP server '{lspserver.name}' is "
   if lspserver.running
     msg ..= 'running'
   else

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -269,11 +269,18 @@ To add a language server, the following information is needed:
 			searched upwards in all the parent directories.  If
 			multiple directories are found, then the directory
 			closest to the directory of the current buffer is used
-			as the workspace root.  If this parameter is not
-			specified or the files are not found, then the current
-			working directory is used as the workspace root for
-			decendent files, for any other files the parent
-			directory of the file is used.
+			as the workspace root.
+
+			This option is also used to decide which server to run
+			when multiple servers are defined for a filetype. The
+			server with the longest found workspace root will be
+			selected as the relevant language server for a given
+			file.
+
+			If this parameter is not specified or the files are not
+			found, then the current working directory is used as the
+			workspace root for decendent files, for any other files
+			the parent directory of the file is used.
 
 Aditionally the following configurations can be made:
 


### PR DESCRIPTION
⚠️ This PR doesn't add support for running multiple LSP servers for a buffer, but rather adds support for registering multiple LSP servers for a given filetype.

The server with the longest workspace root will be chosen as the most relevant server for a given buffer.

Closes #221