### PR TITLE
Add range-end attributes to diagnostic  location list.

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -302,6 +302,7 @@ def DiagsUpdateLocList(lspserver: dict<any>, bnr: number): bool
     qflist->add({filename: fname,
 		    lnum: diag.range.start.line + 1,
 		    col: util.GetLineByteFromPos(bnr, diag.range.start) + 1,
+		    end_lnum: diag.range.end.line + 1,
                     end_col: util.GetLineByteFromPos(bnr, diag.range.end) + 1,
 		    text: text,
 		    type: DiagSevToQfType(diag.severity)})

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -302,6 +302,7 @@ def DiagsUpdateLocList(lspserver: dict<any>, bnr: number): bool
     qflist->add({filename: fname,
 		    lnum: diag.range.start.line + 1,
 		    col: util.GetLineByteFromPos(bnr, diag.range.start) + 1,
+                    end_col: util.GetLineByteFromPos(bnr, diag.range.end) + 1,
 		    text: text,
 		    type: DiagSevToQfType(diag.severity)})
   endfor


### PR DESCRIPTION
This PR adds range-end attributes of diagnostics to the location list, i.e. range.end to the corresponding end_col & end_lnum. Those are currently missing even though they are provided by the language server.