### PR TITLE
Add ":LspShowServer initializeRequest"

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -172,6 +172,8 @@ export def ShowServer(arg: string)
     :echomsg msg
   elseif arg ==? 'capabilities'
     lspserver.showCapabilities()
+  elseif arg ==? 'initializeRequest'
+    lspserver.showInitializeRequest()
   elseif arg ==? 'messages'
     lspserver.showMessages()
   else

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -189,6 +189,8 @@ def InitServer(lspserver: dict<any>, bnr: number)
     initparams.initializationOptions = lspserver.initializationOptions
   endif
 
+  lspserver.rpcInitializeRequest = initparams
+
   lspserver.rpc_a('initialize', initparams, ServerInitReply)
 enddef
 
@@ -1416,6 +1418,23 @@ def ShowCapabilities(lspserver: dict<any>)
   :setlocal nomodifiable
 enddef
 
+# Display the LSP server initialize request and result
+def ShowInitializeRequest(lspserver: dict<any>)
+  OpenScratchWindow($'LangServer-{lspserver.name}-Initialize-Request')
+  var l = []
+  var heading = $"'{lspserver.path}' Language Server Initialize Requst"
+  var underlines = repeat('=', heading->len())
+  l->extend([heading, underlines])
+  if lspserver->has_key('rpcInitializeRequest')
+    for k in lspserver.rpcInitializeRequest->keys()->sort()
+      l->add($'{k}: {lspserver.rpcInitializeRequest[k]->string()}')
+    endfor
+  endif
+  setline(1, l)
+  :setlocal nomodified
+  :setlocal nomodifiable
+enddef
+
 # Display the log messages received from the LSP server (window/logMessage)
 def ShowMessages(lspserver: dict<any>)
   if lspserver.messages->empty()
@@ -1562,6 +1581,7 @@ export def NewLspServer(name_arg: string, path_arg: string, args: list<string>,
     executeCommand: function(ExecuteCommand, [lspserver]),
     workspaceConfigGet: function(WorkspaceConfigGet, [lspserver]),
     showCapabilities: function(ShowCapabilities, [lspserver]),
+    showInitializeRequest: function(ShowInitializeRequest, [lspserver]),
     showMessages: function(ShowMessages, [lspserver])
   })
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -66,7 +66,7 @@ enddef
 
 # Command line completion function for the LspShowServer command.
 def LspShowServerComplete(arglead: string, cmdline: string, cursorpos: number): list<string>
-  var l = ['capabilities', 'messages', 'status']
+  var l = ['capabilities', 'initializeRequest', 'messages', 'status']
   if arglead->empty()
     return l
   else


### PR DESCRIPTION
Since it's now possible to add "rootSearch" which changes the rootUri that is being send to the server I think it makes sense to be able to easily get to this information. I imagine it will be useful when people are reporting issues.

It might make sense to request people, that are doing bug reports, to include the information from:

	:LspShowServer status
	:LspShowServer initializeRequest
	:LspShowServer capabilities

I understand that we already got `:LspShowServer messages` but that requires that logging is enabled, which requires the user to change the configuration and restart vim.