### PR TITLE
Add test to ensure that helptags can be generated without problems

### DIFF
--- a/test/not_lspserver_related_tests.vim
+++ b/test/not_lspserver_related_tests.vim
@@ -1,0 +1,14 @@
+vim9script
+# Unit tests for Vim Language Server Protocol (LSP) for various functionality 
+
+# Test for no duplicates in helptags
+def g:Test_Helptags()
+  :helptags ../doc
+enddef
+
+# Only here to because the test runner needs it
+def g:StartLangServer(): bool
+  return true
+enddef
+
+# vim: shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -10,7 +10,7 @@ fi
 
 VIM_CMD="$VIMPRG -u NONE -U NONE -i NONE --noplugin -N --not-a-term"
 
-TESTS="clangd_tests.vim tsserver_tests.vim gopls_tests.vim"
+TESTS="clangd_tests.vim tsserver_tests.vim gopls_tests.vim not_lspserver_related_tests.vim"
 
 for testfile in $TESTS
 do


### PR DESCRIPTION
The test will raise an exception like:

	Error: Test Test_Helptags() failed with exception Vim(helptags):E154: Duplicate tag "lsp-opt-completionKinds" in file ../doc/lsp.txt at command line..script ~/.vim/pack/plugins/opt/lsp/test/runner.vim[50]..function <SNR>1_LspRunTests[20]..Test_Helptags, line 1

This test was created based on this comment https://github.com/yegappan/lsp/pull/234#issuecomment-1503656397