### PR TITLE
Take the original sorting into account when sorting textedits

### DIFF
--- a/autoload/lsp/textedit.vim
+++ b/autoload/lsp/textedit.vim
@@ -16,7 +16,8 @@ def Edit_sort_func(a: dict<any>, b: dict<any>): number
     return b.A[1] - a.A[1]
   endif
 
-  return 0
+  # Assume that the LSP sorted the lines correctly to begin with
+  return b.idx - a.idx
 enddef
 
 # Replaces text in a range with new text.
@@ -117,6 +118,7 @@ export def ApplyTextEdits(bnr: number, text_edits: list<dict<any>>): void
   var end_col: number
 
   # create a list of buffer positions where the edits have to be applied.
+  var idx = 0
   for e in text_edits
     # Adjust the start and end columns for multibyte characters
     start_row = e.range.start.line
@@ -128,7 +130,9 @@ export def ApplyTextEdits(bnr: number, text_edits: list<dict<any>>): void
 
     updated_edits->add({A: [start_row, start_col],
 			B: [end_row, end_col],
+                        idx: idx,
 			lines: e.newText->split("\n", true)})
+    idx += 1
   endfor
 
   # Reverse sort the edit operations by descending line and column numbers so


### PR DESCRIPTION
Some language servers like "efm-langserver" configured with "prettier" will provide multiple textedits for the same line and column, these are actually sorted "correctly" but since we apply the changes in reverse we need to also take the original sorting into account.

The range provided is something like:

    { start: { line: 10, character: 0 }, end: { line: 10, character: 0 } }

and this is the LSP servers way to provide an insert.