### PR TITLE
fix: E716 when completing inside of a class with intelephense

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -126,7 +126,10 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
     items = cItems
   else
     items = cItems.items
-    lspserver.completeItemsIsIncomplete = cItems.isIncomplete
+
+    if cItems->has_key("isIncomplete")
+      lspserver.completeItemsIsIncomplete = cItems.isIncomplete
+    endif
   endif
 
   # Get the keyword prefix before the current cursor column.


### PR DESCRIPTION
If you type anything inside a PHP class using intelephense (i only tested with it), vim will raise a E716 error saying that the `isIncomplete` field does not exist in the dictionary `cItems`. This is probably a intelephense issue, but if it isn't, this is a fix (or workaround).

Example error:
![image](https://user-images.githubusercontent.com/115833146/231796877-cb4dedc9-a999-4d0b-8001-d260317c9caf.png)

VIM version 9.0.1321
intelephense version 1.9.5 (installed via NPM)
yegappan/lsp on 66e53fe