### PR TITLE
multiple server part 9: Add support for the "features" configuration flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ path|complete path to the LSP server executable (without any arguments).
 args|a list of command-line arguments passed to the LSP server. Each argument is a separate List item.
 initializationOptions|User provided initialization options. May be of any type. For example the *intelephense* PHP language server accept several options here with the License Key among others. 
 customNotificationHandlers|A dictionary of notifications and functions that can be specified to add support for custom language server notifications.
+features|A dictionary of booleans that can be specified to toggle what things a given LSP is providing (folding, goto definition, etc) This is useful when running multiple servers in one buffer.
 
 The LSP servers are added using the LspAddServer() function. This function accepts a list of LSP servers with the above information.
 

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -47,6 +47,10 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
 
   var SupportedCheckFns = {
     'completion': (lspserver) => lspserver.isCompletionProvider,
+    'definition': (lspserver) => lspserver.isDefinitionProvider,
+    'declaration': (lspserver) => lspserver.isDeclarationProvider,
+    'typeDefinition': (lspserver) => lspserver.isTypeDefinitionProvider,
+    'implementation': (lspserver) => lspserver.isImplementationProvider,
     'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
   }
 

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -46,6 +46,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
   endif
 
   var SupportedCheckFns = {
+    'completion': (lspserver) => lspserver.isCompletionProvider,
     'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
   }
 

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -52,6 +52,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
     'typeDefinition': (lspserver) => lspserver.isTypeDefinitionProvider,
     'implementation': (lspserver) => lspserver.isImplementationProvider,
     'hover': (lspserver) => lspserver.isHoverProvider,
+    'references': (lspserver) => lspserver.isReferencesProvider,
     'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
   }
 

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -51,6 +51,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
     'declaration': (lspserver) => lspserver.isDeclarationProvider,
     'typeDefinition': (lspserver) => lspserver.isTypeDefinitionProvider,
     'implementation': (lspserver) => lspserver.isImplementationProvider,
+    'hover': (lspserver) => lspserver.isHoverProvider,
     'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
   }
 

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -59,6 +59,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
     'codeAction': (lspserver) => lspserver.isCodeActionProvider,
     'codeLens': (lspserver) => lspserver.isCodeLensProvider,
     'selectionRange': (lspserver) => lspserver.isSelectionRangeProvider,
+    'foldingRange': (lspserver) => lspserver.isFoldingRangeProvider,
   }
 
   if !SupportedCheckFns->has_key(domain)

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -58,6 +58,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
     'rename': (lspserver) => lspserver.isRenameProvider,
     'codeAction': (lspserver) => lspserver.isCodeActionProvider,
     'codeLens': (lspserver) => lspserver.isCodeLensProvider,
+    'selectionRange': (lspserver) => lspserver.isSelectionRangeProvider,
   }
 
   if !SupportedCheckFns->has_key(domain)

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -55,6 +55,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
     'references': (lspserver) => lspserver.isReferencesProvider,
     'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
     'rename': (lspserver) => lspserver.isRenameProvider,
+    'codeAction': (lspserver) => lspserver.isCodeActionProvider,
   }
 
   if !SupportedCheckFns->has_key(domain)

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -56,6 +56,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
     'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
     'rename': (lspserver) => lspserver.isRenameProvider,
     'codeAction': (lspserver) => lspserver.isCodeActionProvider,
+    'codeLens': (lspserver) => lspserver.isCodeLensProvider,
   }
 
   if !SupportedCheckFns->has_key(domain)

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -54,6 +54,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
     'hover': (lspserver) => lspserver.isHoverProvider,
     'references': (lspserver) => lspserver.isReferencesProvider,
     'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
+    'rename': (lspserver) => lspserver.isRenameProvider,
   }
 
   if !SupportedCheckFns->has_key(domain)

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -53,6 +53,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
     'implementation': (lspserver) => lspserver.isImplementationProvider,
     'hover': (lspserver) => lspserver.isHoverProvider,
     'references': (lspserver) => lspserver.isReferencesProvider,
+    'documentHighlight': (lspserver) => lspserver.isDocumentHighlightProvider,
     'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
     'rename': (lspserver) => lspserver.isRenameProvider,
     'codeAction': (lspserver) => lspserver.isCodeActionProvider,

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -46,6 +46,7 @@ export def BufLspServerGet(bnr: number, domain: string = null_string): dict<any>
   endif
 
   var SupportedCheckFns = {
+    'documentFormatting': (lspserver) => lspserver.isDocumentFormattingProvider,
   }
 
   if !SupportedCheckFns->has_key(domain)

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -369,7 +369,7 @@ enddef
 
 # omni complete handler
 def g:LspOmniFunc(findstart: number, base: string): any
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('completion')
   if lspserver->empty()
     return -2
   endif
@@ -428,7 +428,7 @@ enddef
 # Insert mode completion handler. Used when 24x7 completion is enabled
 # (default).
 def LspComplete()
-  var lspserver: dict<any> = buf.CurbufGetServer()
+  var lspserver: dict<any> = buf.CurbufGetServer('completion')
   if lspserver->empty() || !lspserver.running || !lspserver.ready
     return
   endif
@@ -466,7 +466,7 @@ enddef
 
 # Lazy complete documentation handler
 def LspResolve()
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('completion')
   if lspserver->empty()
     return
   endif
@@ -505,7 +505,7 @@ enddef
 
 # complete done handler (LSP server-initiated actions after completion)
 def LspCompleteDone()
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('completion')
   if lspserver->empty()
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -776,7 +776,7 @@ enddef
 
 # highlight all the places where a symbol is referenced
 def g:LspDocHighlight()
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('documentHighlight')
   if lspserver->empty()
     return
   endif
@@ -786,7 +786,7 @@ enddef
 
 # clear the symbol reference highlight
 def g:LspDocHighlightClear()
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('documentHighlight')
   if lspserver->empty()
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -756,7 +756,7 @@ enddef
 # Display the hover message from the LSP server for the current cursor
 # location
 export def Hover()
-  var lspserver: dict<any> = buf.CurbufGetServer()
+  var lspserver: dict<any> = buf.CurbufGetServer('hover')
   if lspserver->empty() || !lspserver.running || !lspserver.ready
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -883,7 +883,7 @@ enddef
 # Rename a symbol
 # Uses LSP "textDocument/rename" request
 export def Rename(a_newName: string)
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('rename')
   if lspserver->empty()
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -831,7 +831,7 @@ export def TextDocFormat(range_args: number, line1: number, line2: number)
     return
   endif
 
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('documentFormatting')
   if lspserver->empty()
     return
   endif
@@ -1055,7 +1055,7 @@ enddef
 
 # Function to use with the 'formatexpr' option.
 export def FormatExpr(): number
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('documentFormatting')
   if lspserver->empty()
     return 1
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -766,7 +766,7 @@ enddef
 
 # show symbol references
 export def ShowReferences(peek: bool)
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('references')
   if lspserver->empty()
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -1019,7 +1019,7 @@ enddef
 
 # fold the entire document
 export def FoldDocument()
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('foldingRange')
   if lspserver->empty()
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -999,7 +999,7 @@ enddef
 
 # expand the previous selection or start a new selection
 export def SelectionExpand()
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('selectionRange')
   if lspserver->empty()
     return
   endif
@@ -1009,7 +1009,7 @@ enddef
 
 # shrink the previous selection or start a new selection
 export def SelectionShrink()
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('selectionRange')
   if lspserver->empty()
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -918,7 +918,7 @@ enddef
 # Code lens
 # Uses LSP "textDocument/codeLens" request
 export def CodeLens()
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('codeLens')
   if lspserver->empty()
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -598,6 +598,11 @@ export def AddServer(serverList: list<dict<any>>)
       customNotificationHandlers = server.customNotificationHandlers
     endif
 
+    var features: dict<bool> = {}
+    if server->has_key('features')
+      features = server.features
+    endif
+
     if server.omnicompl->type() != v:t_bool
       util.ErrMsg($'Error: Setting of omnicompl {server.omnicompl} is not a Boolean')
       return
@@ -632,7 +637,7 @@ export def AddServer(serverList: list<dict<any>>)
 						    server.workspaceConfig,
 						    server.rootSearch,
 						    customNotificationHandlers,
-						    server.debug)
+						    features, server.debug)
 
     var ftypes = server.filetype
     if ftypes->type() == v:t_string

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -906,7 +906,7 @@ enddef
 # Perform a code action
 # Uses LSP "textDocument/codeAction" request
 export def CodeAction(line1: number, line2: number, query: string)
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('codeAction')
   if lspserver->empty()
     return
   endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -255,7 +255,7 @@ enddef
 
 # Go to a definition using "textDocument/definition" LSP request
 export def GotoDefinition(peek: bool, cmdmods: string)
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('definition')
   if lspserver->empty()
     return
   endif
@@ -265,7 +265,7 @@ enddef
 
 # Go to a declaration using "textDocument/declaration" LSP request
 export def GotoDeclaration(peek: bool, cmdmods: string)
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('declaration')
   if lspserver->empty()
     return
   endif
@@ -275,7 +275,7 @@ enddef
 
 # Go to a type definition using "textDocument/typeDefinition" LSP request
 export def GotoTypedef(peek: bool, cmdmods: string)
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('typeDefinition')
   if lspserver->empty()
     return
   endif
@@ -285,7 +285,7 @@ enddef
 
 # Go to a implementation using "textDocument/implementation" LSP request
 export def GotoImplementation(peek: bool, cmdmods: string)
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('implementation')
   if lspserver->empty()
     return
   endif
@@ -1045,7 +1045,7 @@ enddef
 
 # Function to use with the 'tagfunc' option.
 export def TagFunc(pat: string, flags: string, info: dict<any>): any
-  var lspserver: dict<any> = buf.CurbufGetServerChecked()
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('definition')
   if lspserver->empty()
     return v:null
   endif

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1476,7 +1476,7 @@ export def NewLspServer(name_arg: string, path_arg: string, args: list<string>,
 			workspaceConfig: dict<any>,
 			rootSearchFiles: list<any>,
 			customNotificationHandlers: dict<func>,
-			debug_arg: bool): dict<any>
+			features: dict<bool>, debug_arg: bool): dict<any>
   var lspserver: dict<any> = {
     id: GetUniqueServerId(),
     name: name_arg,
@@ -1485,6 +1485,7 @@ export def NewLspServer(name_arg: string, path_arg: string, args: list<string>,
     syncInit: isSync,
     initializationOptions: initializationOptions,
     customNotificationHandlers: customNotificationHandlers,
+    features: features,
     running: false,
     ready: false,
     job: v:none,

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1364,6 +1364,38 @@ By proving the configuration |lsp-cfg-features| it's possible specify which
 servers should be used for a given method.  The following flags are supported
 >
 #{
+	documentFormatting: true
 }
+<
+
+As shown above the order of when the language servers are being defined is taken
+into account for a given method.  However sometimes the language server that you
+want to use for formatting also reports that it supports other features, in such
+a case you can change the order of language servers, and specify that a given
+language server should be used for a given method.
+
+For example, if you want to use the efm-langserver for formatting, but the
+typescript-language-server for everything else:
+
+	vim9script
+
+	g:LspAddServer([
+		# this language server will be used by default, as it's defined
+		# as the first LSP for 'javascript' and 'typescript'
+		{
+			filetype: ['javascript', 'typescript'],
+			path: '/usr/local/bin/typescript-language-server',
+			args: ['--stdio']
+		},
+		# this language server will be used for documentFormatting
+		{
+			filetype: ['efm-langserver'],
+			path: '/usr/local/bin/efm-langserver',
+			args: [],
+			features: {
+				documentFormatting: true
+			}
+		}
+	])
 <
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1373,7 +1373,8 @@ servers should be used for a given method.  The following flags are supported
 	references: true,
 	documentFormatting: true,
 	rename: true,
-	codeAction: true
+	codeAction: true,
+	codeLens: true
 }
 <
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1371,7 +1371,8 @@ servers should be used for a given method.  The following flags are supported
 	implementation: true,
 	hover: true,
 	references: true,
-	documentFormatting: true
+	documentFormatting: true,
+	rename: true
 }
 <
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1364,6 +1364,7 @@ By proving the configuration |lsp-cfg-features| it's possible specify which
 servers should be used for a given method.  The following flags are supported
 >
 #{
+	completion: true,
 	documentFormatting: true
 }
 <

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1365,6 +1365,10 @@ servers should be used for a given method.  The following flags are supported
 >
 #{
 	completion: true,
+	definition: true,
+	declaration: true,
+	typeDefinition: true,
+	implementation: true,
 	documentFormatting: true
 }
 <

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1369,6 +1369,7 @@ servers should be used for a given method.  The following flags are supported
 	declaration: true,
 	typeDefinition: true,
 	implementation: true,
+	hover: true,
 	documentFormatting: true
 }
 <

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -299,6 +299,11 @@ Aditionally the following configurations can be made:
 			}
 		}])
 <
+					*lsp-cfg-features*
+	features
+			(Optional) toggle which features should be enabled for a
+			given langauge server. See |lsp-multiple-servers| for
+			more information.
 						*lsp-cfg-omnicompl*
 	omnicompl	(Optional) a boolean value that enables (true)
 			or disables (false) omni-completion for this file
@@ -1319,5 +1324,46 @@ In the completion popup, will show something like this: >
 		| create                method() |
 		| createIfNotExists     method() |
 		| ...				 |
+<
+==============================================================================
+16. Multiple Language Servers for a buffer	*lsp-multiple-servers*
+
+It's possible to run multiple language servers for a given buffer.
+
+By default the language server defined first will be used for as much as it
+supports, then the next and so on. With the exception that diagnostics from all
+running language servers will be joined together. This means that you can define
+a language server that only supports a subset of features at first and then
+define the general purpose language server after it: >
+
+		vim9script
+		g:LspAddServer([
+			# This language server reports that it only supports
+			# textDocument/documentFormatting, so it will be used
+			# for :LspFormat but nothing else.
+			{
+				filetype: ['html'],
+				path: 'html-pretty-lsp',
+				args: ['--stdio']
+			},
+			# This language server also supports
+			# textDocument/documentFormatting, but since it's been
+			# defined later, the one above will be used instead.
+			# However this server also supports
+			# textDocument/definition, textDocument/declaration,
+			# etc, so it will be used for :LspGotoDefinition,
+			# :LspGotoDeclaration, etc
+			{
+				filetype: ['html'],
+				path: 'html-language-server',
+				args: ['--stdio']
+			}
+		])
+<
+By proving the configuration |lsp-cfg-features| it's possible specify which
+servers should be used for a given method.  The following flags are supported
+>
+#{
+}
 <
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1370,6 +1370,7 @@ servers should be used for a given method.  The following flags are supported
 	typeDefinition: true,
 	implementation: true,
 	hover: true,
+	references: true,
 	documentFormatting: true
 }
 <

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1372,7 +1372,8 @@ servers should be used for a given method.  The following flags are supported
 	hover: true,
 	references: true,
 	documentFormatting: true,
-	rename: true
+	rename: true,
+	codeAction: true
 }
 <
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1376,7 +1376,8 @@ servers should be used for a given method.  The following flags are supported
 	rename: true,
 	codeAction: true,
 	codeLens: true,
-	selectionRange: true
+	selectionRange: true,
+	foldingRange:  true
 }
 <
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1375,7 +1375,8 @@ servers should be used for a given method.  The following flags are supported
 	documentFormatting: true,
 	rename: true,
 	codeAction: true,
-	codeLens: true
+	codeLens: true,
+	selectionRange: true
 }
 <
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1371,6 +1371,7 @@ servers should be used for a given method.  The following flags are supported
 	implementation: true,
 	hover: true,
 	references: true,
+	documentHighlight: true,
 	documentFormatting: true,
 	rename: true,
 	codeAction: true,


### PR DESCRIPTION
These flags let the user choose which language servers should be used for which methods.

There are still a few places where there havn't been added "feature" flags, for instance:

    'textDocument/switchSourceHeader'
    'textDocument/signatureHelp'
    'callHierarchy/incomingCalls'
    'callHierarchy/outgoingCalls'
    ... and possible others as well

in these cases the first defined language server will be used.

The commits comes from https://github.com/yegappan/lsp/pull/231