### PR TITLE
Raise an error if no hover server is found

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -738,8 +738,8 @@ enddef
 # Display the hover message from the LSP server for the current cursor
 # location
 export def Hover(cmdmods: string)
-  var lspserver: dict<any> = buf.CurbufGetServer('hover')
-  if lspserver->empty() || !lspserver.running || !lspserver.ready
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('hover')
+  if lspserver->empty()
     return
   endif
 


### PR DESCRIPTION
The error message is something like: `Error: Language server for "xx" file type is not found`