### PR TITLE
Add an autocmd for the LSP servers internal ID

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -488,7 +488,7 @@ export def AddFile(bnr: number): void
       BufferInit(lspserver.id, bnr)
     else
       augroup LSPBufferAutocmds
-        exe $'autocmd User LspServerReady{lspserver.name} ++once BufferInit({lspserver.id}, {bnr})'
+        exe $'autocmd User LspServerReady_{lspserver.id} ++once BufferInit({lspserver.id}, {bnr})'
       augroup END
     endif
   endfor

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -127,6 +127,10 @@ def ServerInitReply(lspserver: dict<any>, initResult: dict<any>): void
   if exists($'#User#LspServerReady{lspserver.name}')
     exe $'doautocmd <nomodeline> User LspServerReady{lspserver.name}'
   endif
+  # Used internally, and shouldn't be used by users
+  if exists($'#User#LspServerReady_{lspserver.id}')
+    exe $'doautocmd <nomodeline> User LspServerReady_{lspserver.id}'
+  endif
 
   # if the outline window is opened, then request the symbols for the current
   # buffer


### PR DESCRIPTION
This is to not fail if the user provides two servers with the same name.

Closes #271 