### PR TITLE
Adds option to align diagnostics virtual text

### DIFF
--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -37,6 +37,9 @@ export var lspOptions: dict<any> = {
   # If a snippet plugin is going to apply the text edits, then set this to
   # false to avoid applying the text edits twice.
   completionTextEdit: true,
+  # Alignment of virtual diagnostic text, when showDiagWithVirtualText is true
+  # Allowed values: 'above' | 'below' | 'after' (default is 'above')
+  diagVirtualTextAlign: 'above',
   # instead of the signature
   noDiagHoverOnLine: true,
   # Suppress adding a new line on completion selection with <CR>

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -416,6 +416,11 @@ diagSignInfoText        |String| option. Change diag sign text for info
 						*lsp-opt-diagSignWarningText*
 diagSignWarningText     |String| option. Change diag sign text for warnings
                         By default 'W>',
+						*lsp-opt-diagVirtualTextAlign*
+diagVirtualTextAlign	|String| option.   Alignment of diagnostics messages
+			if |lsp-opt-showDiagWithVirtualText| is set to true. 
+			Allowed values are 'above', 'below' or 'after'
+			By default this is set to 'above',
 						*lsp-opt-echoSignature*
 echoSignature		|Boolean| option.  In insert mode, echo the current
 			symbol signature instead of showing it in a popup.


### PR DESCRIPTION
This is a PR that addresses #260 

This PR provides a new option that allows the configuration of the alignment of the virtual text, which is displayed if the option `showDiagWithVirtualText` is active.

This  is a (first) minimal solution in order to get this new option going. In my opinion without any risks, since the former implementation has been preserved as far as possible.

This PR does not (yet) address the remarks from @andlrc, concerning the order of messages for `below` and @Shane-XB-Qian concerning the limitation of displayed diagnostic messages. In order to resolve these remarks, a more complicated solution needs to be prepared. 

I want to ask you kindly to review all changes, as this is my first larger PR into this code repository.