### PR TITLE
Move `fname` to the end of the arguments in `symbol#DocSymbolReply`

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -928,8 +928,9 @@ def GetDocSymbols(lspserver: dict<any>, fname: string): void
   # interface DocumentSymbolParams
   # interface TextDocumentIdentifier
   var params = {textDocument: {uri: util.LspFileToUri(fname)}}
-  lspserver.rpc_a('textDocument/documentSymbol', params,
-			function(symbol.DocSymbolReply, [fname]))
+  lspserver.rpc_a('textDocument/documentSymbol', params, (_, reply) => {
+    symbol.DocSymbolReply(lspserver, reply, fname)
+  })
 enddef
 
 # Request: "textDocument/formatting"

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -578,7 +578,7 @@ enddef
 # process the 'textDocument/documentSymbol' reply from the LSP server
 # Open a symbols window and display the symbols as a tree
 # Result: DocumentSymbol[] | SymbolInformation[] | null
-export def DocSymbolReply(fname: string, lspserver: dict<any>, docsymbol: any)
+export def DocSymbolReply(lspserver: dict<any>, docsymbol: any, fname: string)
   var symbolTypeTable: dict<list<dict<any>>> = {}
   var symbolLineTable: list<dict<any>> = []
 


### PR DESCRIPTION
Change to use a lambda instead of a funcref for the reply callback for dyc symbols, this allows us to move the `fname` to the end of the `symbol#DocSymbolReply` function.