### PR TITLE
Sort complete items based on `sortText`

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -255,9 +255,21 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
       endif
     endif
 
+    # Score is used for sorting.
+    d.score = item->get('sortText')
+    if d.score->empty()
+      d.score = item->get('label', '')
+    endif
+
     d.user_data = item
     completeItems->add(d)
   endfor
+
+  if opt.lspOptions.completionMatcher != 'fuzzy'
+    # Lexographical sort (case-insensitive).
+    completeItems->sort((a, b) =>
+      a.score ==# b.score ? 0 : a.score >? b.score ? 1 : -1)
+  endif
 
   if opt.lspOptions.autoComplete && !lspserver.omniCompletePending
     if completeItems->empty()


### PR DESCRIPTION
With this, complete items should be sorted in the same way as Visual Studio Code (more or less). Unless the fuzzy matcher is enabled, <del>which then uses `matchfuzzy()` for sorting</del>.

Fixes #281