### PR TITLE
Adapt LspFileTorUri for Cygwin

### DIFF
--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -111,6 +111,11 @@ enddef
 export def LspFileToUri(fname: string): string
   var uri: string = fname->fnamemodify(':p')
 
+  if has("win32unix")
+    # We're in Cygwin
+    uri = CygwinToWindowsPath(uri)
+  endif
+
   var on_windows: bool = false
   if uri =~? '^\a:'
     on_windows = true
@@ -131,6 +136,27 @@ export def LspFileToUri(fname: string): string
   endif
 
   return uri
+enddef
+
+# Convert POSIX paths as used in Cygwin to native Windows paths
+def CygwinToWindowsPath(path: string): string
+  if path =~? '^\/cygdrive\/'
+    # Convert paths of the form "/cygdrive/c/foo/bar" to "C:/foo/bar"
+    return substitute(path, '^\/cygdrive\/\(\a\)\/', '\=submatch(1) .. ":/"', "")
+  elseif path =~? '^\/'
+    # Convert paths of the form "/home/pete/foo" to "C:/cygwin64/home/pete/foo"
+    if len(g:cygwinroot) == 0
+      # https://stackoverflow.com/a/7449029/273348
+      g:cygwinroot = substitute(system("reg query HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Cygwin\\\\setup /v rootdir | grep rootdir"),
+            \ '^\s*\S\+\s\+\S\+\s\+\(\p\+\).*$',
+            \ '\=submatch(1)',
+            \ "")
+    endif
+
+    return $'{g:cygwinroot}{path}'
+  else
+    return path
+  endif
 enddef
 
 # Convert a Vim buffer number to an LSP URI (file://<absolute_path>)

--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -141,13 +141,17 @@ enddef
 # Convert POSIX paths as used in Cygwin to native Windows paths
 def CygwinToWindowsPath(path: string): string
   if path =~? '^\/cygdrive\/'
-    # Convert paths of the form "/cygdrive/c/foo/bar" to "C:/foo/bar"
-    return substitute(path, '^\/cygdrive\/\(\a\)\/', '\=submatch(1) .. ":/"', "")
+    # Convert paths of the form "/cygdrive/c/foo/bar" to "c:/foo/bar"
+
+    return path->substitute('^\/cygdrive\/\(\a\)\/', '\=submatch(1) .. ":/"', "")
   elseif path =~? '^\/'
     # Convert paths of the form "/home/pete/foo" to "C:/cygwin64/home/pete/foo"
-    if len(g:cygwinroot) == 0
+
+    if g:cygwinroot->len() == 0
       # https://stackoverflow.com/a/7449029/273348
-      g:cygwinroot = substitute(system("reg query HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Cygwin\\\\setup /v rootdir | grep rootdir"),
+      var query: string = "reg query HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Cygwin\\\\setup /v rootdir | grep rootdir"
+
+      g:cygwinroot = system(query)->substitute(
             \ '^\s*\S\+\s\+\S\+\s\+\(\p\+\).*$',
             \ '\=submatch(1)',
             \ "")


### PR DESCRIPTION
Language servers are compiled to use the standard Windows paths (although only tested with `rust-analyzer`). But `vim` under `Cygwin` uses POSIX paths. Therefore the paths have to be converted somewhere and `LspFileToUri` seems like the ideal place for it.

The added code detects if the script is being run from `Cygwin` and if so, it convert paths of the form "/cygdrive/c/foo/bar" to "c:/foo/bar" and paths of the form "/home/pete/foo" to "C:/cygwin64/home/pete/foo".

Feel free to suggest changes as this is my first non-one-liner vim script.