### PR TITLE
Add `keepFocusInDiags` option

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -410,13 +410,12 @@ enddef
 # Display the diagnostic messages from the LSP server for the current buffer
 # in a location list
 export def ShowAllDiags(): void
-  var save_winid = win_getid()
-
   if !DiagsUpdateLocList(bufnr())
     util.WarnMsg($'No diagnostic messages found for {@%}')
     return
   endif
 
+  var save_winid = win_getid()
   :lopen
   if !opt.lspOptions.keepFocusInDiags
     save_winid->win_gotoid()

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -410,12 +410,17 @@ enddef
 # Display the diagnostic messages from the LSP server for the current buffer
 # in a location list
 export def ShowAllDiags(): void
+  var save_winid = win_getid()
+
   if !DiagsUpdateLocList(bufnr())
     util.WarnMsg($'No diagnostic messages found for {@%}')
     return
   endif
 
   :lopen
+  if !opt.lspOptions.keepFocusInDiags
+    save_winid->win_gotoid()
+  endif
 enddef
 
 # Display the message of 'diag' in a popup window right below the position in

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -32,9 +32,9 @@ export var lspOptions: dict<any> = {
   # Don't print message when a configured language server is missing.
   ignoreMissingServer: false,
   # Focus on the location list window after LspDiagShow
-  keepFocusInDiags: false,
+  keepFocusInDiags: true,
   # Focus on the location list window after LspShowReferences
-  keepFocusInReferences: false,
+  keepFocusInReferences: true,
   # If true, apply the LSP server supplied text edits after a completion.
   # If a snippet plugin is going to apply the text edits, then set this to
   # false to avoid applying the text edits twice.

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -31,6 +31,8 @@ export var lspOptions: dict<any> = {
   hoverInPreview: false,
   # Don't print message when a configured language server is missing.
   ignoreMissingServer: false,
+  # Focus on the location list window after LspDiagShow
+  keepFocusInDiags: true,
   # Focus on the location list window after LspShowReferences
   keepFocusInReferences: false,
   # If true, apply the LSP server supplied text edits after a completion.

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -32,7 +32,7 @@ export var lspOptions: dict<any> = {
   # Don't print message when a configured language server is missing.
   ignoreMissingServer: false,
   # Focus on the location list window after LspDiagShow
-  keepFocusInDiags: true,
+  keepFocusInDiags: false,
   # Focus on the location list window after LspShowReferences
   keepFocusInReferences: false,
   # If true, apply the LSP server supplied text edits after a completion.

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -438,6 +438,10 @@ hoverInPreview		|Boolean| option. Show |:LspHover| in a preview window
 						*lsp-opt-ignoreMissingServer*
 ignoreMissingServer	|Boolean| option.  Do not print a missing language
 			server executable.  By default this is set to false.
+						*lsp-opt-keepFocusInDiags*
+keepFocusInDiags     	|Boolean| option.  Focus on the location list window
+			after LspDiagShow.
+			By default this is set to true.
 						*lsp-opt-keepFocusInReferences*
 keepFocusInReferences	|Boolean| option.  Focus on the location list window
 			after LspShowReferences.

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -441,7 +441,7 @@ ignoreMissingServer	|Boolean| option.  Do not print a missing language
 						*lsp-opt-keepFocusInDiags*
 keepFocusInDiags     	|Boolean| option.  Focus on the location list window
 			after LspDiagShow.
-			By default this is set to true.
+			By default this is set to false.
 						*lsp-opt-keepFocusInReferences*
 keepFocusInReferences	|Boolean| option.  Focus on the location list window
 			after LspShowReferences.

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -491,11 +491,11 @@ ignoreMissingServer	|Boolean| option.  Do not print a missing language
 						*lsp-opt-keepFocusInDiags*
 keepFocusInDiags     	|Boolean| option.  Focus on the location list window
 			after LspDiagShow.
-			By default this is set to false.
+			By default this is set to true.
 						*lsp-opt-keepFocusInReferences*
 keepFocusInReferences	|Boolean| option.  Focus on the location list window
 			after LspShowReferences.
-			By default this is set to false.
+			By default this is set to true.
 						*lsp-opt-noDiagHoverOnLine*
 noDiagHoverOnLine	|Boolean| option.  Suppress diagnostic hover from
 			appearing when the mouse is over the line instead of

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -185,7 +185,7 @@ def g:Test_LspShowReferences()
   assert_equal([4, 6], [loclist[0].lnum, loclist[0].col])
   assert_equal([5, 2], [loclist[1].lnum, loclist[1].col])
   assert_equal([6, 6], [loclist[2].lnum, loclist[2].col])
-  :only
+  :lclose
   cursor(1, 5)
   :LspShowReferences
   assert_equal(1, getloclist(0)->len())
@@ -199,13 +199,13 @@ def g:Test_LspShowReferences()
   :LspShowReferences
   sleep 100m
   assert_equal('quickfix', getwinvar(winnr('$'), '&buftype'))
+  :cclose
   var qfl: list<dict<any>> = getqflist()
   assert_equal(3, qfl->len())
   assert_equal(bufnr(), qfl[0].bufnr)
   assert_equal([4, 6], [qfl[0].lnum, qfl[0].col])
   assert_equal([5, 2], [qfl[1].lnum, qfl[1].col])
   assert_equal([6, 6], [qfl[2].lnum, qfl[2].col])
-  :only
   cursor(1, 5)
   :LspShowReferences
   assert_equal(1, getqflist()->len())
@@ -214,12 +214,12 @@ def g:Test_LspShowReferences()
   :cclose
   g:LspOptionsSet({ useQuickfixForLocations: false })
 
-  # Test for moving buffer focus to loclist
-  g:LspOptionsSet({ keepFocusInReferences: true })
-  :LspShowReferences
-  assert_equal('quickfix', getwinvar(0, '&buftype'))
-  :lclose
+  # Test for maintaining buffer focus
   g:LspOptionsSet({ keepFocusInReferences: false })
+  :LspShowReferences
+  assert_equal('', getwinvar(0, '&buftype'))
+  :lclose
+  g:LspOptionsSet({ keepFocusInReferences: true })
 
   # Test for LspPeekReferences
 
@@ -282,7 +282,7 @@ def g:Test_LspDiag()
   assert_equal([3, 14, 'E'], [qfl[0].lnum, qfl[0].col, qfl[0].type])
   assert_equal([5, 2, 'W'], [qfl[1].lnum, qfl[1].col, qfl[1].type])
   assert_equal([7, 2, 'W'], [qfl[2].lnum, qfl[2].col, qfl[2].type])
-  :lclose
+  close
   g:LspOptionsSet({showDiagInPopup: false})
   normal gg
   var output = execute('LspDiagCurrent')->split("\n")
@@ -306,12 +306,12 @@ def g:Test_LspDiag()
   output = execute('LspDiagPrev')->split("\n")
   assert_equal('Warn: No more diagnostics found', output[0])
 
-  # Test for moving buffer focus to loclist
-  g:LspOptionsSet({ keepFocusInDiags: true })
-  :LspDiagShow
-  assert_equal('quickfix', getwinvar(0, '&buftype'))
-  :lclose
+  # Test for maintaining buffer focus
   g:LspOptionsSet({ keepFocusInDiags: false })
+  :LspDiagShow
+  assert_equal('', getwinvar(0, '&buftype'))
+  :lclose
+  g:LspOptionsSet({ keepFocusInDiags: true })
 
   # :[count]LspDiagNext
   cursor(3, 1)
@@ -435,7 +435,7 @@ def g:Test_LspDiag_Multi()
   endif
   assert_equal([1, 9, 'E'], [qfl[1].lnum, qfl[1].col, qfl[1].type])
   assert_equal([2, 9, 'E'], [qfl[2].lnum, qfl[2].col, qfl[2].type])
-  :lclose
+  close
 
   :sleep 100m
   cursor(2, 1)
@@ -1363,6 +1363,7 @@ def g:Test_ScanFindIdent()
   cursor(6, 10)
   assert_equal([],
 	       execute('LspShowReferences')->split("\n"))
+  :lclose
 
   # LspRename
   cursor(6, 10)

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -202,6 +202,13 @@ def g:Test_LspShowReferences()
   :cclose
   g:LspOptionsSet({ useQuickfixForLocations: false })
 
+  # Test for moving buffer focus to loclist
+  g:LspOptionsSet({ keepFocusInReferences: true })
+  :LspShowReferences
+  assert_equal('quickfix', getwinvar(0, '&buftype'))
+  :lclose
+  g:LspOptionsSet({ keepFocusInReferences: false })
+
   # Test for LspPeekReferences
 
   # Opening the preview window with an unsaved buffer displays the "E37: No
@@ -286,6 +293,13 @@ def g:Test_LspDiag()
   :LspDiagPrev
   output = execute('LspDiagPrev')->split("\n")
   assert_equal('Warn: No more diagnostics found', output[0])
+
+  # Test for maintaining buffer focus
+  g:LspOptionsSet({ keepFocusInDiags: false })
+  :LspDiagShow
+  assert_equal('', getwinvar(0, '&buftype'))
+  :lclose
+  g:LspOptionsSet({ keepFocusInDiags: true })
 
   # :[count]LspDiagNext
   cursor(3, 1)

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -270,7 +270,7 @@ def g:Test_LspDiag()
   assert_equal([3, 14, 'E'], [qfl[0].lnum, qfl[0].col, qfl[0].type])
   assert_equal([5, 2, 'W'], [qfl[1].lnum, qfl[1].col, qfl[1].type])
   assert_equal([7, 2, 'W'], [qfl[2].lnum, qfl[2].col, qfl[2].type])
-  close
+  :lclose
   g:LspOptionsSet({showDiagInPopup: false})
   normal gg
   var output = execute('LspDiagCurrent')->split("\n")
@@ -294,12 +294,12 @@ def g:Test_LspDiag()
   output = execute('LspDiagPrev')->split("\n")
   assert_equal('Warn: No more diagnostics found', output[0])
 
-  # Test for maintaining buffer focus
-  g:LspOptionsSet({ keepFocusInDiags: false })
-  :LspDiagShow
-  assert_equal('', getwinvar(0, '&buftype'))
-  :lclose
+  # Test for moving buffer focus to loclist
   g:LspOptionsSet({ keepFocusInDiags: true })
+  :LspDiagShow
+  assert_equal('quickfix', getwinvar(0, '&buftype'))
+  :lclose
+  g:LspOptionsSet({ keepFocusInDiags: false })
 
   # :[count]LspDiagNext
   cursor(3, 1)
@@ -394,7 +394,7 @@ def g:Test_LspDiag_Multi()
   endif
   assert_equal([1, 9, 'E'], [qfl[1].lnum, qfl[1].col, qfl[1].type])
   assert_equal([2, 9, 'E'], [qfl[2].lnum, qfl[2].col, qfl[2].type])
-  close
+  :lclose
 
   :sleep 100m
   cursor(2, 1)


### PR DESCRIPTION
This option serves a similar purpose to `keepFocusInReferences` but for `LspDiagShow` rather than `LspShowReferences`. Note that the default behaviour is changed by this PR as  `keepFocusInDiags` defaults to false.