### PR TITLE
Custom ref highlight

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -31,9 +31,13 @@ var ftypeServerMap: dict<list<dict<any>>> = {}
 var lspInitializedOnce = false
 
 def LspInitOnce()
-  prop_type_add('LspTextRef', {highlight: 'Search', override: true})
-  prop_type_add('LspReadRef', {highlight: 'DiffChange', override: true})
-  prop_type_add('LspWriteRef', {highlight: 'DiffDelete', override: true})
+  hlset([{name: 'LspTextRef', default: true, linksto: 'Search'}])
+  hlset([{name: 'LspReadRef', default: true, linksto: 'DiffChange'}])
+  hlset([{name: 'LspWriteRef', default: true, linksto: 'DiffDelete'}])
+
+  prop_type_add('LspTextRef', {highlight: 'LspTextRef', override: true})
+  prop_type_add('LspReadRef', {highlight: 'LspReadRef', override: true})
+  prop_type_add('LspWriteRef', {highlight: 'LspWriteRef', override: true})
 
   diag.InitOnce()
   inlayhints.InitOnce()

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -35,9 +35,9 @@ def LspInitOnce()
   hlset([{name: 'LspReadRef', default: true, linksto: 'DiffChange'}])
   hlset([{name: 'LspWriteRef', default: true, linksto: 'DiffDelete'}])
 
-  prop_type_add('LspTextRef', {highlight: 'LspTextRef', override: true})
-  prop_type_add('LspReadRef', {highlight: 'LspReadRef', override: true})
-  prop_type_add('LspWriteRef', {highlight: 'LspWriteRef', override: true})
+  prop_type_add('LspTextRef', {highlight: 'LspTextRef'})
+  prop_type_add('LspReadRef', {highlight: 'LspReadRef'})
+  prop_type_add('LspWriteRef', {highlight: 'LspWriteRef'})
 
   diag.InitOnce()
   inlayhints.InitOnce()


### PR DESCRIPTION
Make it possible to define custom highlights for ref created via `:LspHighlight`.

Also prevent these highlights from overriding visual selection, hlsearch etc.