### PR TITLE
Add option "showDiagSource"

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -272,6 +272,9 @@ export def DiagNotification(lspserver: dict<any>, uri: string, newDiags: list<di
 
   var diagWithinRange: list<dict<any>> = []
   for diag in newDiags
+    if opt.lspOptions.showDiagSource
+      diag.message = $'{lspserver.name}: {diag.message}'
+    endif
     if diag.range.start.line + 1 > lastlnum
       # Make sure the line number is a valid buffer line number
       diag.range.start.line = lastlnum - 1

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -53,6 +53,9 @@ export var lspOptions: dict<any> = {
   # Suppress diagnostic hover from appearing when the mouse is over the line
   # Show a diagnostic message on a status line
   showDiagOnStatusLine: false,
+  # Show which language server a diagnostic is comming from, by prefixing the
+  # diagnostic message with the language servers name.
+  showDiagSource: false,
   # Show a diagnostic messages with virtual text
   showDiagWithVirtualText: false,
   # enable inlay hints

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -470,6 +470,13 @@ showDiagInPopup		|Boolean| option.  When using the |:LspDiagCurrent|
 						*lsp-opt-showDiagOnStatusLine*
 showDiagOnStatusLine	|Boolean| option.  Show a diagnostic message on a
 			status line.  By default this is set to false.
+						*lsp-opt-showDiagSource*
+showDiagSource		|Boolean| option. Show which language server a
+			diagnostic is comming from, by prefixing the diagnostic
+			message with the language servers name. This option
+			makes most sense when using multiple language servers in
+			the same buffer, see |lsp-multiple-servers|.  By default
+			this is set to false.
 						*lsp-opt-showDiagWithVirtualText*
 showDiagWithVirtualText	|Boolean| option.  Show diagnostic message text from
 			the language server with virtual text.  By default


### PR DESCRIPTION
This will add an option to prefix each diagnostic message with the name of the language server from which the diagnostic is coming from.