### PR TITLE
Ignore non-standard request from eclipse java LS

### DIFF
--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -200,9 +200,17 @@ export def ProcessRequest(lspserver: dict<any>, request: dict<any>)
       'workspace/semanticTokens/refresh': ProcessUnsupportedReq
     }
 
+  # Explicitly ignored requests
+  var lspIgnoredRequestHandlers: list<string> =
+    [
+      # Eclipse java language server sends the 'workspace/executeClientCommand' 
+      # request (to reload bundles) which is not in the LSP specification.
+      'workspace/executeClientCommand',
+    ]
+
   if lspRequestHandlers->has_key(request.method)
     lspRequestHandlers[request.method](lspserver, request)
-  else
+  elseif lspIgnoredRequestHandlers->index(request.method) == -1
     util.ErrMsg($'Unsupported request message received from the LSP server ({lspserver.path}), message = {request->string()}')
   endif
 enddef

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -705,7 +705,7 @@ def GotoSymbolLoc(lspserver: dict<any>, msg: string, peekSymbol: bool,
       endif
     endif
 
-    # Select the location requsted in 'count'
+    # Select the location requested in 'count'
     var idx = count - 1
     if idx >= reply.result->len()
       idx = reply.result->len() - 1
@@ -1426,7 +1426,7 @@ enddef
 # Display the LSP server initialize request and result
 def GetInitializeRequest(lspserver: dict<any>): list<string>
   var l = []
-  var heading = $"'{lspserver.path}' Language Server Initialize Requst"
+  var heading = $"'{lspserver.path}' Language Server Initialize Request"
   var underlines = repeat('=', heading->len())
   l->extend([heading, underlines])
   if lspserver->has_key('rpcInitializeRequest')


### PR DESCRIPTION
Eclipse java language server sends the 'workspace/executeClientCommand' request (to reload bundles) which is not in the LSP specification. Ignore this request and suppress the error message.

Fixed typos in lspserver.vim

M  autoload/lsp/handlers.vim
M  autoload/lsp/lspserver.vim