### PR TITLE
Add priority to props

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -179,7 +179,8 @@ def DiagsRefresh(bnr: number)
     var lnum = diag.range.start.line + 1
     signs->add({id: 0, buffer: bnr, group: 'LSPDiag',
 				lnum: lnum,
-				name: DiagSevToSignName(diag.severity)})
+				name: DiagSevToSignName(diag.severity),
+				priority: 10 - diag.severity})
 
     try
       if opt.lspOptions.highlightDiagInline

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -59,13 +59,13 @@ export def InitOnce()
   hlset([{name: 'LspDiagInlineInfo', default: true, linksto: 'SpellRare'}])
   hlset([{name: 'LspDiagInlineHint', default: true, linksto: 'SpellLocal'}])
   prop_type_add('LspDiagInlineError',
-                      { highlight: 'LspDiagInlineError' })
+                      { highlight: 'LspDiagInlineError', priority: 10 })
   prop_type_add('LspDiagInlineWarning',
-                      { highlight: 'LspDiagInlineWarning' })
+                      { highlight: 'LspDiagInlineWarning', priority: 9 })
   prop_type_add('LspDiagInlineInfo',
-                      { highlight: 'LspDiagInlineInfo' })
+                      { highlight: 'LspDiagInlineInfo', priority: 8 })
   prop_type_add('LspDiagInlineHint',
-                      { highlight: 'LspDiagInlineHint' })
+                      { highlight: 'LspDiagInlineHint', priority: 7 })
 
   hlset([{name: 'LspDiagVirtualText', default: true, linksto: 'LineNr'}])
   prop_type_add('LspDiagVirtualText', {highlight: 'LspDiagVirtualText',


### PR DESCRIPTION
With the following code:

```
#include <ctype.h>
#include <stdio.h>
void aFunc(void)
{
    printf("%s", z, tolower("aaa"));
    printf("%s", tolower("aaa"), z);
}
```

Line 5 and 6 will both be highlighted as errors, instead of today where line 5 will be highlighted as a warning, because `tolower("aaa")` overrides the error rendered by `z`.

The props used to highlight inline diagnostics are also being prioritized.