### PR TITLE
Skip invalid servers instead of aborting

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -598,13 +598,13 @@ export def AddServer(serverList: list<dict<any>>)
       if !opt.lspOptions.ignoreMissingServer
         util.ErrMsg($'LSP server {server.path} is not found')
       endif
-      return
+      continue
     endif
     var args: list<string> = []
     if server->has_key('args')
       if server.args->type() != v:t_list
         util.ErrMsg($'Arguments for LSP server {server.args} is not a List')
-        return
+        continue
       endif
       args = server.args
     endif
@@ -623,7 +623,7 @@ export def AddServer(serverList: list<dict<any>>)
     if server->has_key('processDiagHandler')
       if server.processDiagHandler->type() != v:t_func
         util.ErrMsg($'Setting of processDiagHandler {server.processDiagHandler} is not a Funcref nor lambda')
-        return
+        continue
       endif
       ProcessDiagHandler = server.processDiagHandler
     endif
@@ -640,7 +640,7 @@ export def AddServer(serverList: list<dict<any>>)
 
     if server.omnicompl->type() != v:t_bool
       util.ErrMsg($'Setting of omnicompl {server.omnicompl} is not a Boolean')
-      return
+      continue
     endif
 
     if !server->has_key('syncInit')


### PR DESCRIPTION
Right now with `ignoreMissingServer` set, when calling `LspAddServer()` with a list of servers where the very first entry is invalid, but the remaining ones are valid, no servers are added.

It seems highly unintuitive to me that the `ignoreMissingServer` option only silences the warning, but still aborts the whole call even if the remaining servers in the list are valid.

For example, I am calling:
```vim
au VimEnter * call LspAddServer([
	\ #{ name: 'nix', filetype: ['nix'], path: 'nil' },
	\ #{ name: 'bash', filetype: ['sh'], path: 'bash-language-server', args: ['start'] },
	\ #{ name: 'cpp', filetype: ['c', 'cpp'], path: 'clangd', args: ['--background-index'] },
	\ #{ name: 'haskell', filetype: ['haskell'], path: 'haskell-language-server', args: ['--lsp'] },
	\ #{ name: 'qml', filetype: ['qml'], path: 'qmlls6' },
	\ #{ name: 'rust', filetype: ['rust'], path: 'rust-analyzer', syncInit: 1 },
\ ])
```

But the nix language server is only available, when I am inside a `nix-shell`, which means that as a sideeffect all other LSPs are not added as well, even though they are available.


This patch fixes this by just continuing with the next element in the list, if the option is set.