### PR TITLE
Fix rare out-of-bounds issue with getbufline()

### DIFF
--- a/autoload/lsp/outline.vim
+++ b/autoload/lsp/outline.vim
@@ -194,7 +194,7 @@ def OutlineHighlightCurrentSymbol()
 
   # Highlight the selected symbol
   var col: number =
-	bnr->getbufline(symbolTable[mid].outlineLine)[0]->match('\S') + 1
+	bnr->getbufoneline(symbolTable[mid].outlineLine)->match('\S') + 1
   prop_add(symbolTable[mid].outlineLine, col,
 			{bufnr: bnr, type: 'LspOutlineHighlight',
 			length: symbolTable[mid].name->len()})

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -349,8 +349,8 @@ def PeekLocations(lspserver: dict<any>, locations: list<dict<any>>,
       bnr->bufload()
     endif
 
-    var text: string = bnr->getbufline(range.start.line + 1)[0]
     var lnum = range.start.line + 1
+    var text: string = bnr->getbufoneline(lnum)
     menuItems->add($'{lnum}: {text}')
   endfor
 
@@ -392,7 +392,7 @@ export def ShowLocations(lspserver: dict<any>, locations: list<dict<any>>,
     if !bnr->bufloaded()
       bnr->bufload()
     endif
-    var text: string = bnr->getbufline(range.start.line + 1)[0]->trim("\t ", 1)
+    var text: string = bnr->getbufoneline(range.start.line + 1)->trim("\t ", 1)
     qflist->add({filename: fname,
 			lnum: range.start.line + 1,
 			col: util.GetLineByteFromPos(bnr, range.start) + 1,

--- a/autoload/lsp/textedit.vim
+++ b/autoload/lsp/textedit.vim
@@ -173,7 +173,7 @@ export def ApplyTextEdits(bnr: number, text_edits: list<dict<any>>): void
   # lines.
   var dellastline: bool = false
   if start_line == 0 && bnr->getbufinfo()[0].linecount == 1 &&
-						bnr->getbufline(1)[0] == ''
+						bnr->getbufoneline(1) == ''
     dellastline = true
   endif
 

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -464,14 +464,14 @@ def g:Test_LspDiag_Multi()
   assert_equal([1, 5], [line('.'), col('.')])
   var ids = popup_list()
   assert_equal(1, ids->len())
-  assert_match('Incompatible pointer to integer', getbufline(ids[0]->winbufnr(), 1, '$')[0])
+  assert_match('Incompatible pointer to integer', getbufoneline(ids[0]->winbufnr(), 1, '$'))
   popup_clear()
   cursor(1, 6)
   :LspDiagHere
   assert_equal([1, 9], [line('.'), col('.')])
   ids = popup_list()
   assert_equal(1, ids->len())
-  assert_match('Initializer element is not', getbufline(ids[0]->winbufnr(), 1, '$')[0])
+  assert_match('Initializer element is not', getbufoneline(ids[0]->winbufnr(), 1, '$'))
   popup_clear()
 
   # Line without diagnostics


### PR DESCRIPTION
I don't have exact steps to reproduce this, but sometimes the LSP sends back some invalid data, such that in `PeekLocations()`, `getbufline()` will return an empty set, causing the `[0]` to be out of bounds:
```
Error detected while processing function lsp#lsp#ShowReferences[6]..<SNR>62_ShowReferences[20]..lsp#symbol#ShowLocatio
ns[2]..<SNR>70_PeekLocations:
line   21:
E684: List index out of range: 0
```

Luckily this can easily be fixed by replacing `getbufline()[0]` with `getbufoneline()`, which will just return an empty string in those cases and avoid the error.
