### PR TITLE
Fix completepopup colors

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -604,11 +604,10 @@ export def BufferInit(lspserver: dict<any>, bnr: number, ftype: string)
   if opt.lspOptions.autoComplete
     if lspserver.completionLazyDoc
       setbufvar(bnr, '&completeopt', 'menuone,popuphidden,noinsert,noselect')
-      setbufvar(bnr, '&completepopup', 'width:80,highlight:Pmenu,align:item,border:off')
     else
       setbufvar(bnr, '&completeopt', 'menuone,popup,noinsert,noselect')
-      setbufvar(bnr, '&completepopup', 'border:off')
     endif
+    setbufvar(bnr, '&completepopup', 'width:80,highlight:Pmenu,align:item,border:off')
     # <Enter> in insert mode stops completion and inserts a <Enter>
     if !opt.lspOptions.noNewlineInCompletion
       :inoremap <expr> <buffer> <CR> pumvisible() ? "\<C-Y>\<CR>" : "\<CR>"


### PR DESCRIPTION
The branch for LSP servers providing documentation on demand via "resolveProvider" already fixed this, but documentation can also be available without the completionLazyDoc setting. Since the style of the info popup shouldn't differ in these cases, let's unify the `completepopup` style for both branches. Otherwise the colors of the info popup might look weird if they are colored with `PmenuSel`:

## Before
![Screenshot_20230601_012555](https://github.com/yegappan/lsp/assets/21310755/0529b34d-012d-4e29-8b5a-668088ef171d)

## After
![Screenshot_20230601_011411](https://github.com/yegappan/lsp/assets/21310755/0306a674-1c34-44ec-a276-139f97ae97fe)
