### PR TITLE
Add support for hrsh7th/vim-vsnip plugin

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -155,7 +155,7 @@ def CompletionVsnip(items: list<dict<any>>)
     if match[0] != ''
       var user_data = item.user_data->json_decode()
       var documentation = []
-      for line in user_data.vsnip.snippet->vsnip#to_string()->split("\n")
+      for line in vsnip#to_string(user_data.vsnip.snippet)->split("\n")
 	documentation->add(line)
       endfor
       items->add({

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -140,8 +140,8 @@ enddef
 # Integration with the vim-vsnip plugin
 def CompletionVsnip(items: list<dict<any>>)
   def Pattern(abbr: string): string
-    var chars = split(escape(abbr, '\/?'), '\zs')
-    var chars_pattern = '\%(\V' .. join(chars, '\m\|\V') .. '\m\)'
+    var chars = escape(abbr, '\/?')->split('\zs')
+    var chars_pattern = '\%(\V' .. chars->join('\m\|\V') .. '\m\)'
     var separator = chars[0] =~ '\a' ? '\<' : ''
     return separator .. '\V' .. chars[0] .. '\m' .. chars_pattern .. '*$'
   enddef
@@ -153,9 +153,9 @@ def CompletionVsnip(items: list<dict<any>>)
   for item in vsnip#get_complete_items(bufnr('%'))
     var match = starttext->matchstrpos(Pattern(item.abbr))
     if match[0] != ''
-      var user_data = json_decode(item.user_data)
+      var user_data = item.user_data->json_decode()
       var documentation = []
-      for line in split(vsnip#to_string(user_data.vsnip.snippet), "\n")
+      for line in user_data.vsnip.snippet->vsnip#to_string()->split("\n")
 	documentation->add(line)
       endfor
       items->add({
@@ -163,7 +163,7 @@ def CompletionVsnip(items: list<dict<any>>)
 	filterText: item.word,
 	insertTextFormat: 2,
 	textEdit: {
-	  newText: join(user_data.vsnip.snippet, "\n"),
+	  newText: user_data.vsnip.snippet->join("\n"),
 	  range: {
 	    start: {
 	      line: line('.'),

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -143,7 +143,7 @@ def CompletionVsnip(items: list<dict<any>>)
     var chars = escape(abbr, '\/?')->split('\zs')
     var chars_pattern = '\%(\V' .. chars->join('\m\|\V') .. '\m\)'
     var separator = chars[0] =~ '\a' ? '\<' : ''
-    return separator .. '\V' .. chars[0] .. '\m' .. chars_pattern .. '*$'
+    return $'{separator}\V{chars[0]}\m{chars_pattern}*$'
   enddef
 
   if charcol('.') == 1

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -657,11 +657,10 @@ export def BufferInit(lspserver: dict<any>, bnr: number, ftype: string)
   if opt.lspOptions.autoComplete
     if lspserver.completionLazyDoc
       setbufvar(bnr, '&completeopt', 'menuone,popuphidden,noinsert,noselect')
-      setbufvar(bnr, '&completepopup', 'width:80,highlight:Pmenu,align:item,border:off')
     else
       setbufvar(bnr, '&completeopt', 'menuone,popup,noinsert,noselect')
-      setbufvar(bnr, '&completepopup', 'border:off')
     endif
+    setbufvar(bnr, '&completepopup', 'width:80,highlight:Pmenu,align:item,border:off')
     # <Enter> in insert mode stops completion and inserts a <Enter>
     if !opt.lspOptions.noNewlineInCompletion
       :inoremap <expr> <buffer> <CR> pumvisible() ? "\<C-Y>\<CR>" : "\<CR>"

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -65,6 +65,8 @@ export var lspOptions: dict<any> = {
   snippetSupport: false,
   # enable SirVer/ultisnips completion support
   ultisnipsSupport: false,
+  # enable hrsh7th/vim-vsnip completion support
+  vsnipSupport: false,
   # Use a floating menu to show the code action menu instead of asking for input
   usePopupInCodeAction: false,
   # ShowReferences in a quickfix list instead of a location list`

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -546,7 +546,8 @@ ultisnipsSupport	|Boolean| option.  Enable SirVer/ultisnips support.
 						*lsp-opt-vssnipSupport*
 vsnipSupport		|Boolean| option.  Enable hrsh7th/vim-vsnip support.
 			Need snippet completion plugins hrsh7th/vim-vsnip
-		 	and hrsh7th/vim-vsnip-integ. By default this is
+		 	and hrsh7th/vim-vsnip-integ. Set ultisnipsSupport to
+			false before enabling this. By default this is
 			set to false.
 						*lsp-opt-usePopupInCodeAction*
 usePopupInCodeAction    |Boolean| option.  When using the |:LspCodeAction|

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -546,9 +546,9 @@ ultisnipsSupport	|Boolean| option.  Enable SirVer/ultisnips support.
 						*lsp-opt-vssnipSupport*
 vsnipSupport		|Boolean| option.  Enable hrsh7th/vim-vsnip support.
 			Need snippet completion plugins hrsh7th/vim-vsnip
-		 	and hrsh7th/vim-vsnip-integ. Set ultisnipsSupport to
-			false before enabling this. By default this is
-			set to false.
+		 	and hrsh7th/vim-vsnip-integ.  Make sure ultisnipsSupport
+			is set to false before enabling this.  By default 
+			this option is set to false.
 						*lsp-opt-usePopupInCodeAction*
 usePopupInCodeAction    |Boolean| option.  When using the |:LspCodeAction|
 			command to display the code action for the current

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -543,6 +543,11 @@ snippetSupport		|Boolean| option.  Enable snippet completion support.
 ultisnipsSupport	|Boolean| option.  Enable SirVer/ultisnips support.
 			Need a snippet completion plugin SirVer/ultisnips.
 			By default this is set to false.
+						*lsp-opt-vssnipSupport*
+vsnipSupport		|Boolean| option.  Enable hrsh7th/vim-vsnip support.
+			Need snippet completion plugins hrsh7th/vim-vsnip
+		 	and hrsh7th/vim-vsnip-integ. By default this is
+			set to false.
 						*lsp-opt-usePopupInCodeAction*
 usePopupInCodeAction    |Boolean| option.  When using the |:LspCodeAction|
 			command to display the code action for the current


### PR DESCRIPTION
### Summary

This enhancement enables **hrsh7th/vim-vsnip** plugin to complete user defined snippets. Without this enhancement vim-vsnip could only expand LSP provided snippets.

- Query vim-vsnip plugin for snippet completions and add the items to the completion list.
- Add a boolean flag to set vsnip completion option
- Update documentation
- Based on hrsh7th/cmp-vsnip

#### Following plugins need to be installed

[required] hrsh7th/vim-vsnip
[required] hrsh7th/vim-vsnip-integ
[optional] rafamadriz/friendly-snippets

#### Options should be set as follows
```
completionTextEdit: false,
snippetSupport: true,
vsnipSupport: true,
ultisnipsSupport: false,
```
#### Shortcoming

Completion is not triggered for non-keyword characters like '#' (ex. # before #if in C) even though _vim-vsnip_ interface is capable of such completion, unless LSP server sets special characters as trigger characters. This is not a major shortcoming since it will expand once a keyword character is typed (say, #i in #if). It is also easy to fix this by triggering Snippet completion without triggering LSP completion for non-keyword characters, but some code reorganization is needed first. I would also favor separation of 'completion' mechanism from the LSP client core.

#### Keybindings

User can define keymaps for Tab completion as follows: 
(\<Space\> will expand the snippet)
```
def! g:WhitespaceOnly(): bool
    return strpart(getline('.'), col('.') - 2, 1) =~ '^\s*$'
enddef
def! g:LspCleverTab(): string
    return pumvisible() ? "\<c-n>" : vsnip#jumpable(1) ? "\<Plug>(vsnip-jump-next)" : g:WhitespaceOnly() ? "\<tab>" : "\<c-n>"
enddef
def! g:LspCleverSTab(): string
    return pumvisible() ? "\<c-p>" : vsnip#jumpable(-1) ? "\<Plug>(vsnip-jump-prev)" : g:WhitespaceOnly() ? "\<s-tab>" : "\<c-p>"
enddef
autocmd FileType java,c,cpp,python
            \| inoremap <expr> <tab> g:LspCleverTab()
            \| snoremap <expr> <tab> g:LspCleverTab()
            \| inoremap <expr> <S-Tab> g:LspCleverSTab()
            \| snoremap <expr> <S-Tab> g:LspCleverSTab()
```
M  autoload/lsp/completion.vim
M  autoload/lsp/options.vim
M  doc/lsp.txt
