### PR TITLE
Fix bug where buffer completion spams

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -228,8 +228,9 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
       # snippet completion.  Needs a snippet plugin to expand the snippet.
       # Remove all the snippet placeholders
       d.word = MakeValidWord(d.word)
-    elseif !lspserver.completeItemsIsIncomplete
-      # Don't attempt to filter on the items, when "isIncomplete" is set
+    elseif !lspserver.completeItemsIsIncomplete || opt.lspOptions.useBufferCompletion
+      # Filter items only when "isIncomplete" is set (otherwise server would
+      #   have done the filtering) or when buffer completion is enabled
 
       # plain text completion
       if prefix != ''


### PR DESCRIPTION
Steps to reproduce:
- Enable buffer completion
- Set the matching option to 'case'
- Search for 'xyz' where 'xy' has completions
- Backspace to remove 'z'
- You'll see all items from current buffer show up in completion list that are not related to 'xy'


M  autoload/lsp/completion.vim