### PR TITLE
Implement Ale integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Some of the LSP plugin features can be enabled or disabled by using the LspOptio
 Here is an example of configuration with default values:
 ```viml
 call LspOptionsSet(#{
+	\   aleSupport: v:false,
 	\   autoComplete: v:true,
 	\   autoHighlight: v:false,
 	\   autoHighlightDiags: v:true,

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -82,6 +82,10 @@ export def InitOnce()
   hlset([{name: 'LspDiagVirtualText', default: true, linksto: 'LineNr'}])
   prop_type_add('LspDiagVirtualText', {highlight: 'LspDiagVirtualText',
                                        override: true})
+
+  if opt.lspOptions.aleSupport
+    autocmd_add([{group: 'LspAleCmds', event: 'User', pattern: 'ALEWantResults', cmd: 'AleHook(g:ale_want_results_buffer)'}])
+  endif
 enddef
 
 # Sort diagnostics ascending based on line and character offset
@@ -235,6 +239,29 @@ def DiagsRefresh(bnr: number)
   signs->sign_placelist()
 enddef
 
+# Sends diagnostics to Ale
+def SendAleDiags(bnr: number, timerid: number)
+  if !diagsMap->has_key(bnr)
+    return
+  endif
+
+  # Conver to Ale's diagnostics format (:h ale-loclist-format)
+  ale#other_source#ShowResults(bnr, 'lsp', diagsMap[bnr].sortedDiagnostics->mapnew((_, v) => {
+     return {text: v.message,
+             lnum: v.range.start.line + 1,
+             col: util.GetLineByteFromPos(bnr, v.range.start) + 1,
+             end_lnum: v.range.end.line + 1,
+             end_col: util.GetLineByteFromPos(bnr, v.range.end) + 1,
+             type: "EWIH"[v.severity - 1]}
+  }))
+enddef
+
+# Hook called when Ale wants to retrieve new diagnostics
+def AleHook(bnr: number)
+  ale#other_source#StartChecking(bnr, 'lsp')
+  timer_start(0, function('SendAleDiags', [bnr]))
+enddef
+
 # New LSP diagnostic messages received from the server for a file.
 # Update the signs placed in the buffer for this file
 export def ProcessNewDiags(bnr: number)
@@ -242,7 +269,10 @@ export def ProcessNewDiags(bnr: number)
     DiagsUpdateLocList(bnr)
   endif
 
-  if !opt.lspOptions.autoHighlightDiags
+  if opt.lspOptions.aleSupport
+    SendAleDiags(bnr, -1)
+    return
+  elseif !opt.lspOptions.autoHighlightDiags
     return
   endif
 

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -3,6 +3,10 @@ vim9script
 # LSP plugin options
 # User can override these by calling the OptionsSet() function.
 export var lspOptions: dict<any> = {
+  # Enable ale diagnostics support.
+  # If true, diagnostics will be sent to ale, which will be responsible for
+  # showing them.
+  aleSupport: false,
   # In insert mode, complete the current symbol automatically
   # Otherwise, use omni-completion
   autoComplete: true,

--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -168,12 +168,9 @@ export def GetLineByteFromPos(bnr: number, pos: dict<number>): number
       bnr->bufload()
     endif
 
-    var ltext: list<string> = bnr->getbufline(pos.line + 1)
-    if !ltext->empty()
-      var bidx = ltext[0]->byteidx(col)
-      if bidx != -1
-	return bidx
-      endif
+    var bidx = GetBufOneLine(bnr, pos.line + 1)->byteidx(col)
+    if bidx != -1
+      return bidx
     endif
   endif
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -412,6 +412,11 @@ Some of the LSP plugin features can be enabled or disabled by using the
 LspOptionsSet() function. This function accepts a dictionary argument with the
 following optional items:
 
+						*lsp-opt-aleSupport*
+aleSupport		|Boolean| option. If true, diagnostics will be sent to
+			Ale, instead of being displayed by this plugin.
+			This is useful to combine all LSP and linter
+			diagnostics. By default this is set to false.
 						*lsp-opt-autoComplete*
 autoComplete		|Boolean| option. In insert mode, automatically
 			complete the current symbol. Otherwise use


### PR DESCRIPTION
This adds an `aleSupport` option that is off by default. If enabled, the plugin will send all diagnostics to [Ale](https://github.com/dense-analysis/ale) which allows them to be displayed together with all other linter warnings and improves integration, e.g. all diagnostics will be available in the location list regardless of whether they come from Ale or if they come from lsp.

This is the equivalent to the `"diagnostic.displayByAle"` option in coc.nvim.

Here is a demo where all linter warnings and LSP warnings are displayed nicely together:
![242944188-4a232dc7-10bf-4352-98db-7c2716d24a29](https://github.com/yegappan/lsp/assets/21310755/09052826-b8b2-4b09-b5d8-f7bf5bf90ac6)




The first warning comes from clazy (a linter, that is not available as LSP and only in Ale) and the second and third warning come from lsp, which were then sent to Ale for display.
