### PR TITLE
Respect autoHighlightDiags when reloading a buffer

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -215,6 +215,11 @@ enddef
 # Refresh the placed diagnostics in buffer "bnr"
 # This inline signs, inline props, and virtual text diagnostics
 export def DiagsRefresh(bnr: number, all: bool = false)
+  var lspOpts = opt.lspOptions
+  if !lspOpts.autoHighlightDiags || lspOpts.aleSupport
+    return
+  endif
+
   :silent! bnr->bufload()
 
   RemoveDiagVisualsForBuffer(bnr, all)
@@ -228,7 +233,6 @@ export def DiagsRefresh(bnr: number, all: bool = false)
   var diag_align: string = 'above'
   var diag_wrap: string = 'truncate'
   var diag_symbol: string = '┌─'
-  var lspOpts = opt.lspOptions
 
   if lspOpts.diagVirtualTextAlign == 'below'
     diag_align = 'below'
@@ -331,9 +335,6 @@ export def ProcessNewDiags(bnr: number)
   var lspOpts = opt.lspOptions
   if lspOpts.aleSupport
     SendAleDiags(bnr, -1)
-    return
-  elseif !lspOpts.autoHighlightDiags
-    return
   endif
 
   if bnr == -1 || !diagsMap->has_key(bnr)

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -107,6 +107,7 @@ export def InitOnce()
 
   # ALE plugin support
   if opt.lspOptions.aleSupport
+    opt.lspOptions.autoHighlightDiags = false
     autocmd_add([
       {
 	group: 'LspAleCmds',
@@ -216,7 +217,7 @@ enddef
 # This inline signs, inline props, and virtual text diagnostics
 export def DiagsRefresh(bnr: number, all: bool = false)
   var lspOpts = opt.lspOptions
-  if !lspOpts.autoHighlightDiags || lspOpts.aleSupport
+  if !lspOpts.autoHighlightDiags
     return
   endif
 

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -1343,7 +1343,7 @@ def g:Test_LspTagFunc()
   :exe "normal \<C-]>"
   assert_equal([11, 6], [line('.'), col('.')])
   cursor(1, 1)
-  assert_fails('exe "normal \<C-]>"', 'E433: No tags file')
+  assert_fails('exe "normal \<C-]>"', 'E433:')
 
   :set tagfunc&
   :%bw!


### PR DESCRIPTION
In 6e4ba22, a regression was introduced, that caused this plugin to
ignore both the aleSupport and the autoHighlightDiags option when
reloading a buffer, meaning that the plugin would highlight diagnostics
even when the user explicitly told it not to.
