### PR TITLE
Bug fix in omnifunc

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -427,15 +427,10 @@ def g:LspOmniFunc(findstart: number, base: string): any
     lspserver.getCompletion(1, '')
 
     # locate the start of the word
-    var line = getline('.')
-    var start = charcol('.') - 1
-    var keyword: string = ''
-    while start > 0 && line[start - 1] =~ '\k'
-      keyword = line[start - 1] .. keyword
-      start -= 1
-    endwhile
+    var line = getline('.')->strpart(0, col('.') - 1)
+    var keyword = line->matchstr('\k\+$')
     lspserver.omniCompleteKeyword = keyword
-    return line->byteidx(start)
+    return line->len() - keyword->len()
   else
     # Wait for the list of matches from the LSP server
     var count: number = 0
@@ -470,6 +465,13 @@ def g:LspOmniFunc(findstart: number, base: string): any
 
     return res->filter((i, v) => v.word->stridx(prefix) == 0)
   endif
+enddef
+
+# For plugins that implement async completion from various sources this function
+#   indicates if omnifunc is waiting for LSP response.
+def g:LspOmniCompletePending(): bool
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('completion')
+  return !lspserver->empty() && lspserver.omniCompletePending
 enddef
 
 # Insert mode completion handler. Used when 24x7 completion is enabled


### PR DESCRIPTION
1) LspOmniFunc() causes inserted text (when selecting from a popup) to
   appear in the wrong column. This happens *only* when using this
   function separately (through `complete()` function) in combination
   with other completion functions. When findstart=1, this function
   returns column width of 1 for tab (if tabstop is set to 8), instead
   of 8. To fix the problem I replaced use of `charcol()` with
   `col()`. `:h complete-functions` recommends using `col()`.
   Normal users of omnifunc (<c-x><c-o>) should not notice any
   difference.

2) Added a function to check if omnifunc is waiting for LSP response.
   This is helpful for writing adapters for external completion
   plugins out there.

Since LspOmniFunc() works correctly when used with <c-x><c-o>
this PR is not essential. I leave it to the discretion of Yegappan to
decide whether to include or not.

I use this omnifunc in conjunction with other omnifunc's. I call
them first with findstart=1 and then again with findstart=0, then
combine the returned items and show them using `complete()`.
I use them in async manner. **The advantage of this change is that
now you can adapt this LSP to any external completion plugin
using few lines of stub code.**

Here is how the bug shifts popup window (and inserts in wrong column):

 ![image](https://i.imgur.com/DyPOHNw.png)

M  autoload/lsp/completion.vim