### PR TITLE
Omnifunc optimization and readiness indicator

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -488,6 +488,13 @@ def g:LspOmniFunc(findstart: number, base: string): any
   endif
 enddef
 
+# For plugins that implement async completion this function indicates if
+# omnifunc is waiting for LSP response.
+def g:LspOmniCompletePending(): bool
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('completion')
+  return !lspserver->empty() && lspserver.omniCompletePending
+enddef
+
 # Insert mode completion handler. Used when 24x7 completion is enabled
 # (default).
 def LspComplete()

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -441,15 +441,10 @@ def g:LspOmniFunc(findstart: number, base: string): any
     lspserver.getCompletion(1, '')
 
     # locate the start of the word
-    var line = getline('.')
-    var start = charcol('.') - 1
-    var keyword: string = ''
-    while start > 0 && line[start - 1] =~ '\k'
-      keyword = line[start - 1] .. keyword
-      start -= 1
-    endwhile
+    var line = getline('.')->strpart(0, col('.') - 1)
+    var keyword = line->matchstr('\k\+$')
     lspserver.omniCompleteKeyword = keyword
-    return line->byteidx(start)
+    return line->len() - keyword->len()
   else
     # Wait for the list of matches from the LSP server
     var count: number = 0

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1257,6 +1257,18 @@ do the filtering.  By default, case sensitive comparison is used to filter the
 returned items.  You can modify the 'completionMatcher' option to use either
 case insensitive or fuzzy comparison.
 
+In addition to the automatic completion and omni completion, it is possible to
+use external completion engines which provide asynchronous completion
+from various sources. LSP client can be used as a completion source by
+repurposing `g:LspOmniFunc` function. It needs to be invoked twice as
+described in |complete-functions|. After the first invocation a request is
+sent to the LSP server to find completion candidates. Later the function is
+called again to actually obtain the matches. If the LSP server has not replied
+with the matches `g:LspOmniFunc` could wait up to 2 seconds. To avoid blocking
+wait call `g:LspOmniCompletePending` function which returns `true` immediately
+if LSP server is not ready. `g:LspOmniFunc` should be called the second time
+only after this function returns `false`.
+
 ==============================================================================
 7. Diagnostics						*lsp-diagnostics*
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1258,25 +1258,20 @@ returned items.  You can modify the 'completionMatcher' option to use either
 case insensitive or fuzzy comparison.
 
 In addition to the automatic completion and omni completion, it is possible to
-use external completion engines which provide asynchronous completion
-from various sources. LSP client can be used as a completion source by
-repurposing `g:LspOmniFunc` function. It needs to be invoked twice as
+use external completion engines. LSP client can be used as a completion source
+by repurposing `g:LspOmniFunc` function. It needs to be invoked twice as
 described in |complete-functions|. After the first invocation a request is
-sent to the LSP server to find completion candidates. Later the function is
-called again to actually obtain the matches. If the LSP server has not replied
-with the matches `g:LspOmniFunc` could wait up to 2 seconds. To avoid blocking
-wait call `g:LspOmniCompletePending` function which returns `true` immediately
-if LSP server is not ready. `g:LspOmniFunc` should be called the second time
-only after this function returns `false`.
+sent to the LSP server to find completion candidates. Second invocation
+returns the matches from LSP server. If the LSP server is not ready to reply
+`g:LspOmniFunc` waits for up to 2 seconds. This wait blocks the caller from
+doing other work, which may be a concern for asynchronous completion engines.
+To avoid blocking wait call `g:LspOmniCompletePending` function which returns
+`true` immediately if LSP server is not ready. `g:LspOmniFunc` can be
+called (the second time) only after this function returns `false`.
 
 ==============================================================================
 7. Diagnostics						*lsp-diagnostics*
-
-When a source file has syntax errors or warnings or static analysis warnings,
-the LSP plugin highlights them by placing |signs| in the |sign-column|.  You
-can use the ":LspDiag show" command to display all the diagnostic messages for
-the current file in a |location-list-window|.  You can use the
-":LspDiag first" command to jump to the line with the first diagnostic
+When a source file has syntax errors or warnings or static analysis warnings, the LSP plugin highlights them by placing |signs| in the |sign-column|.  You can use the ":LspDiag show" command to display all the diagnostic messages for the current file in a |location-list-window|.  You can use the ":LspDiag first" command to jump to the line with the first diagnostic
 message, the ":LspDiag next" command to jump to the next nearest line with the
 diagnostic message, the ":LspDiag prev" command to jump to the previous
 nearest line with the diagnostic message, the ":LspDiag here" command to jump

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1258,20 +1258,26 @@ returned items.  You can modify the 'completionMatcher' option to use either
 case insensitive or fuzzy comparison.
 
 In addition to the automatic completion and omni completion, it is possible to
-use external completion engines. LSP client can be used as a completion source
-by repurposing `g:LspOmniFunc` function. It needs to be invoked twice as
-described in |complete-functions|. After the first invocation a request is
-sent to the LSP server to find completion candidates. Second invocation
-returns the matches from LSP server. If the LSP server is not ready to reply
-`g:LspOmniFunc` waits for up to 2 seconds. This wait blocks the caller from
+use external completion engines.  LSP client can be used as a completion source
+by repurposing `g:LspOmniFunc` function.  The adapter which interfaces with
+the external completion engine should invoke this function twice as
+described in |complete-functions|.  After the first invocation a request is
+sent to the LSP server to find completion candidates.  Second invocation
+returns the matches from LSP server.  If the LSP server is not ready to reply
+`g:LspOmniFunc` waits for up to 2 seconds.  This wait blocks the caller from
 doing other work, which may be a concern for asynchronous completion engines.
 To avoid blocking wait call `g:LspOmniCompletePending` function which returns
-`true` immediately if LSP server is not ready. `g:LspOmniFunc` can be
+`true` immediately if LSP server is not ready.  `g:LspOmniFunc` can be
 called (the second time) only after this function returns `false`.
 
 ==============================================================================
 7. Diagnostics						*lsp-diagnostics*
-When a source file has syntax errors or warnings or static analysis warnings, the LSP plugin highlights them by placing |signs| in the |sign-column|.  You can use the ":LspDiag show" command to display all the diagnostic messages for the current file in a |location-list-window|.  You can use the ":LspDiag first" command to jump to the line with the first diagnostic
+
+When a source file has syntax errors or warnings or static analysis warnings,
+the LSP plugin highlights them by placing |signs| in the |sign-column|.  You
+can use the ":LspDiag show" command to display all the diagnostic messages for
+the current file in a |location-list-window|.  You can use the
+":LspDiag first" command to jump to the line with the first diagnostic
 message, the ":LspDiag next" command to jump to the next nearest line with the
 diagnostic message, the ":LspDiag prev" command to jump to the previous
 nearest line with the diagnostic message, the ":LspDiag here" command to jump


### PR DESCRIPTION
There are 2 changes in this PR.

1) Reduce regex comparison overhead in `LspOmniFunc()`.
2) Add a new function to check if LSP server has responded to request from omnifunc. With this change it is possible to write adapters to external async completion plugins. See document (`lsp.txt`) for more details.