### PR TITLE
fix: keep omnicompl really default enable

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -571,14 +571,9 @@ export def AddServer(serverList: list<dict<any>>)
       util.ErrMsg('LSP server information is missing filetype or path')
       continue
     endif
+
     # Enable omni-completion by default
-    var omnicompl_def: bool = false
-    if opt.lspOptions.omniComplete == true
-	|| (opt.lspOptions.omniComplete == null
-	    && !opt.lspOptions.autoComplete)
-      omnicompl_def = true
-    endif
-    server.omnicompl = server->get('omnicompl', omnicompl_def)
+    server.omnicompl = server->get('omnicompl', opt.lspOptions.omniComplete)
 
     if !server.path->executable()
       if !opt.lspOptions.ignoreMissingServer

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -73,9 +73,8 @@ export var lspOptions: dict<any> = {
   # Suppress adding a new line on completion selection with <CR>
   noNewlineInCompletion: false,
 
-  # Omni-completion support.  To keep backward compatibility, this option is
-  # set to null by default instead of false.
-  omniComplete: null,
+  # Omni-completion support.
+  omniComplete: true,
 
   # Open outline window on right side
   outlineOnRight: false,


### PR DESCRIPTION
`omnicompl` option was default `true` really, the recent change made it be possible `false`.
// this to fix it.