### PR TITLE
omnifunc documentation popup should not throw error

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -538,7 +538,7 @@ def LspResolve()
 
   var item = v:event.completed_item
   if item->has_key('user_data') && !item.user_data->empty()
-      if !item.user_data->has_key('documentation')
+      if item.user_data->type() == v:t_dict && !item.user_data->has_key('documentation')
 	lspserver.resolveCompletion(item.user_data)
       else
 	ShowCompletionDocumentation(item.user_data)


### PR DESCRIPTION
When using Omni completion with other sources of completion items that do not have 'user_data' dictionary, documentation popup should not throw error.

I am using my own completion plugin with g:LspOmniFunc and I need LSP to grab lazy-doc from lsp server. But it should not throw error when user_data does not contain dictionary.

M  autoload/lsp/completion.vim