### PR TITLE
fix: ignore `eslint/status` and `taplo/didChangeSchemaAssociation`

### DIFF
--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -116,7 +116,9 @@ export def ProcessNotif(lspserver: dict<any>, reply: dict<any>): void
       # pyright language server notifications
       'pyright/beginProgress',
       'pyright/reportProgress',
-      'pyright/endProgress'
+      'pyright/endProgress',
+      'eslint/status',
+      'taplo/didChangeSchemaAssociation'
     ]
 
   if lsp_notif_handlers->has_key(reply.method)


### PR DESCRIPTION
Ignore `eslint/status` and `taplo/didChangeSchemaAssociation` unsupported notification messages