### PR TITLE
fix: initialize needOffsetEncoding in NewLspServer

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1826,6 +1826,7 @@ export def NewLspServer(serverParams: dict<any>): dict<any>
     forceOffsetEncoding: serverParams.forceOffsetEncoding,
     initializationOptions: serverParams.initializationOptions->deepcopy(),
     messages: [],
+    needOffsetEncoding: false,
     omniCompletePending: false,
     peekSymbolFilePopup: -1,
     peekSymbolPopup: -1,


### PR DESCRIPTION
It's possible for diagnostics to arrive before the initialization message, causing:

```
Error detected while processing function <SNR>23_Output_cb[5]..lsp#handlers#ProcessMessages[32]..lsp#handlers#ProcesNotif[38]..<SNR>24_ProcessDiagNotif[2]..lsp#diag#DiagNotification:
line   15:
E716: Key not present in Dictionary: "needOffsetEncoding"
E716: Key not present in Dictionary: "needOffsetEncoding"
```

Ensuring the key is initialized in `NewLspServer` is one way to fix it.