### PR TITLE
Add support for CompletionItem commands

### DIFF
--- a/autoload/lsp/textedit.vim
+++ b/autoload/lsp/textedit.vim
@@ -213,7 +213,6 @@ export def ApplyWorkspaceEdit(workspaceEdit: dict<any>)
     return
   endif
 
-  var save_cursor: list<number> = getcurpos()
   for [uri, changes] in workspaceEdit.changes->items()
     var bnr: number = util.LspUriToBufnr(uri)
     if bnr == 0
@@ -224,8 +223,6 @@ export def ApplyWorkspaceEdit(workspaceEdit: dict<any>)
     # interface TextEdit
     ApplyTextEdits(bnr, changes)
   endfor
-  # Restore the cursor to the location before the edit
-  save_cursor->setpos('.')
 enddef
 
 # vim: tabstop=8 shiftwidth=2 softtabstop=2


### PR DESCRIPTION
This patch implements support for the optional "command" field in the `CompletionItem` response to a "completionItem/resolve" request: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem


Some language servers (e.g. haskell-language-server) use this field to apply other edits to the document (e.g. auto-importing functions).
While the spec technically says that "additionalTextEdits" should be used for that usecase (also see #367), apparently not all servers do and I can see the reason, because haskell-language-server also wants to show an "window/showMessage" info message to the user about the auto-import.
