### PR TITLE
Fixes duplicate suggestions for servers like volar-server

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -296,6 +296,9 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
     endif
 
     d.user_data = item
+
+    # Some servers like volar-server sends duplicates
+    completeItems = filter(completeItems, (_, i) => i.abbr != d.abbr && i.kind != d.kind)
     completeItems->add(d)
   endfor
 


### PR DESCRIPTION
volar-server sends duplicates, items with the same kind and abbr. This addition makes sure there is only one of each instance. 

Note, if there are better properties to use for the comparison please change to those instead.