### PR TITLE
fix: send buffer text on textDocument/didSave

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -907,8 +907,11 @@ def DidSaveFile(lspserver: dict<any>, bnr: number): void
   # Notification: 'textDocument/didSave'
   # Params: DidSaveTextDocumentParams
   var params = {textDocument: {uri: util.LspBufnrToUri(bnr)}}
-  # FIXME: Need to set "params.text" when
-  # 'lspserver.caps.textDocumentSync.save.includeText' is set to true.
+
+  if lspserver.caps.textDocumentSync.save.includeText
+    params.textDocument.text = bnr->getbufline(1, '$')->join("\n") .. "\n"
+  endif
+
   lspserver.sendNotification('textDocument/didSave', params)
 enddef
 


### PR DESCRIPTION
This sends the full buffer text on the textDocument/didSave notification if the server's sync options specify it.

I'm not exactly sure how to unit test this, as I am a Neovim user, but I am attempting to get this LSP client
working with my new LSP for Elixir, [Next LS](https://github.com/elixir-tools/next-ls).

It uses the text property on this notification.
