### PR TITLE
Avoid moving the cursor when applying textedits

### DIFF
--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -118,6 +118,13 @@ def g:Test_LspFormat()
     }
   END
   assert_equal(expected, getline(1, '$'))
+
+  deletebufline('', 1, '$')
+  # shrinking multiple lines into a single one works
+  setline(1, ['int \', 'i \', '= \', '42;'])
+  :redraw!
+  :4LspFormat
+  assert_equal(['int i = 42;'], getline(1, '$'))
   bw!
 
   # empty file


### PR DESCRIPTION
Currently the `ApplyTextEdits()` code loses the cursor position, because it applies the text edits by deleting the entire range with `deletebufline()` and then adding the new range with `appendbufline()`.
Obviously the cursor will move, if it happens to be inside this range, which is often the case (e.g. when renaming a variable).

This is also apparently the reason, why in the past there was a workaround that saved the cursor position before applying any edits, and then restored it afterwards.
That workaround was already (correctly) removed with: https://github.com/yegappan/lsp/pull/389#issuecomment-1705501598

Instead of reintroducing the workaround, this patch avoids losing the cursor position altogether by not deleting the entire range, but only deleting lines that actually need to be deleted (and adding new lines that actually need to be added).

In my opinion this solution is even simpler code-wise than it was before where we removed the entire region.

I also added a new test case for the scenario where lines have to be removed, all other cases already have test cases.

## Demo

**The old behaviour is on the left side**: After renaming the variable, the cursor jumps to the end of the range.
**The new behaviour is on the right side**: After renaming the variable, the cursor does not move.

https://github.com/yegappan/lsp/assets/21310755/e17a7be1-a0cb-4597-9ab1-4edb12905d02

