### PR TITLE
Remove E1013 error when lsp sends kind=null

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -263,7 +263,7 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
       d.icase = 1
     endif
 
-    if item->has_key('kind')
+    if item->has_key('kind') && !item.kind->empty()
       # namespace CompletionItemKind
       # map LSP kind to complete-item-kind
       d.kind = LspCompleteItemKindChar(item.kind)

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -263,7 +263,7 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
       d.icase = 1
     endif
 
-    if item->has_key('kind') && !item.kind->empty()
+    if item->has_key('kind') && item.kind != null
       # namespace CompletionItemKind
       # map LSP kind to complete-item-kind
       d.kind = LspCompleteItemKindChar(item.kind)


### PR DESCRIPTION
This is what pyslp sent:
{'label': '''H''', 'data': {'doc_uri': 'file:///filename.py'},'sortText': 'a''H''', 'kind': null, 'insertText': '''H'''}
'kind' property need to be checked for null before attempting completion.

M  autoload/lsp/completion.vim