### PR TITLE
Convert file path returned from LSP in Cygwin

### DIFF
--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -85,7 +85,12 @@ export def LspUriToFile(uri: string): string
   if uri_decoded =~? '^file:///\a:'
     # MS-Windows URI
     uri_decoded = uri_decoded[8 : ]
-    uri_decoded = uri_decoded->substitute('/', '\\', 'g')
+    if has("win32unix")  # we're in Cygwin
+      # The substitution is to remove the '^@' escape character from the end of line.
+      uri_decoded = system($'cygpath --unix {uri_decoded}')->substitute('^\(\p*\).*$', '\=submatch(1)', "")
+    else
+      uri_decoded = uri_decoded->substitute('/', '\\', 'g')
+    endif
   # On GNU/Linux (pattern not end with `:`)
   elseif uri_decoded =~? '^file:///\a'
     uri_decoded = uri_decoded[7 : ]


### PR DESCRIPTION
Conversion in the other direction is performed below, in `LspFileToUri` function. This direction was missing and this PR adds that.