### PR TITLE
Add an extra space to LspInlayHintsParam to make it legible

### DIFF
--- a/autoload/lsp/inlayhints.vim
+++ b/autoload/lsp/inlayhints.vim
@@ -57,6 +57,7 @@ export def InlayHintsReply(lspserver: dict<any>, bnr: number, inlayHints: any)
 	prop_add(hint.position.line + 1, byteIdx + 1,
 	  {type: 'LspInlayHintsType', text: label, bufnr: bnr})
       elseif kind == "'parameter'" || kind == '2'
+        label = label .. " "
 	prop_add(hint.position.line + 1, byteIdx + 1,
 	  {type: 'LspInlayHintsParam', text: label, bufnr: bnr})
       endif


### PR DESCRIPTION
`neovim`
![screenshot_1706078950](https://github.com/yegappan/lsp/assets/55893621/ec1f9a59-bb38-4182-86f7-a37ebe2918bc)

`vim-lsp`
![screenshot_1706078932](https://github.com/yegappan/lsp/assets/55893621/c4fce796-ba81-4138-8eb4-c1e7a67b80f4)

`Fix`
![screenshot_1706080105](https://github.com/yegappan/lsp/assets/55893621/6378fe92-3a6b-4cda-bb83-6024b4b3157e)
