### PR TITLE
Improve signature popup window

### DIFF
--- a/autoload/lsp/signature.vim
+++ b/autoload/lsp/signature.vim
@@ -109,7 +109,7 @@ export def SignatureHelp(lspserver: dict<any>, sighelp: any): void
     # Close the previous signature popup and open a new one
     lspserver.signaturePopup->popup_close()
 
-    var popupID = text->popup_atcursor({moved: [col('.') - 1, 9999999]})
+    var popupID = text->popup_atcursor({padding: [0, 1, 0, 1], moved: [col('.') - 1, 9999999]})
     var bnr: number = popupID->winbufnr()
     prop_type_add('signature', {bufnr: bnr, highlight: 'LspSigActiveParameter'})
     if hllen > 0

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -838,9 +838,9 @@ def SymbolMenuFilterKey(symPopupMenu: number,
       win_execute(symPopupMenu, "normal! G")
     endif
   elseif key == "\<PageDown>"
-    win_execute(symPopupMenu, 'normal! ' .. "\<C-d>")
+    win_execute(symPopupMenu, "normal! \<C-d>")
   elseif key == "\<PageUp>"
-    win_execute(symPopupMenu, 'normal! ' .. "\<C-u>")
+    win_execute(symPopupMenu, "normal! \<C-u>")
   elseif key == "\<C-F>"
       || key == "\<C-B>"
       || key == "\<C-Home>"

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -802,7 +802,7 @@ enddef
 # Key filter function for the symbol popup menu.
 def SymbolMenuFilterKey(symPopupMenu: number,
 			key: string): bool
-  var keyHandled = false
+  var keyHandled = true
   var updateInputPopup = false
   var inputText = symPopupMenu->getwinvar('inputText', '')
   var symInputPopup = symPopupMenu->getwinvar('symbolInputPopup', 0)
@@ -811,33 +811,48 @@ def SymbolMenuFilterKey(symPopupMenu: number,
     # Erase a character in the input popup
     if inputText->len() >= 1
       inputText = inputText[: -2]
-      keyHandled = true
       updateInputPopup = true
+    else
+      keyHandled = false
     endif
   elseif key == "\<C-U>"
     # Erase all the characters in the input popup
     inputText = ''
-    keyHandled = true
     updateInputPopup = true
+  elseif key == "\<tab>"
+      || key == "\<C-n>"
+      || key == "\<Down>"
+      || key == "\<ScrollWheelDown>"
+    var ln = getcurpos(symPopupMenu)[1]
+    win_execute(symPopupMenu, "normal! j")
+    if ln == getcurpos(symPopupMenu)[1]
+      win_execute(symPopupMenu, "normal! gg")
+    endif
+  elseif key == "\<S-tab>"
+      || key == "\<C-p>"
+      || key == "\<Up>"
+      || key == "\<ScrollWheelUp>"
+    var ln = getcurpos(symPopupMenu)[1]
+    win_execute(symPopupMenu, "normal! k")
+    if ln == getcurpos(symPopupMenu)[1]
+      win_execute(symPopupMenu, "normal! G")
+    endif
+  elseif key == "\<PageDown>"
+    win_execute(symPopupMenu, 'normal! ' .. "\<C-d>")
+  elseif key == "\<PageUp>"
+    win_execute(symPopupMenu, 'normal! ' .. "\<C-u>")
   elseif key == "\<C-F>"
       || key == "\<C-B>"
-      || key == "\<PageUp>"
-      || key == "\<PageDown>"
       || key == "\<C-Home>"
       || key == "\<C-End>"
-      || key == "\<C-N>"
-      || key == "\<C-P>"
-    # scroll the symbol popup window
-    var cmd: string = 'normal! ' .. (key == "\<C-N>" ? 'j' :
-				     key == "\<C-P>" ? 'k' : key)
-    win_execute(symPopupMenu, cmd)
-    keyHandled = true
+    win_execute(symPopupMenu, $"normal! {key}")
   elseif key =~ '^\k$'
     # A keyword character is typed.  Add to the input text and update the
     # popup
     inputText ..= key
-    keyHandled = true
     updateInputPopup = true
+  else
+    keyHandled = false
   endif
 
   var symTblFiltered: list<dict<any>> = []

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -773,10 +773,13 @@ can map these commands to keys and make it easier to invoke them.
 			pressing <Enter> or <Space>, jump to the location of
 			the symbol.
 
-			The <Up>, <Down>, <C-F>, <C-B>, <PageUp>, <PageDown>,
-			<C-Home>, <C-End>, <C-N>, <C-P> keys can be used to
-			scroll the popup menu.  The <Esc> or <Ctrl-C> keys can
-			be used to cancel the popup menu.
+			The <Up>, <Down>, <Tab>, <S-Tab>, <C-N>, <C-P>,
+			<ScrollWheelUp>, ScrollWheelDown> keys can be used to
+			scroll popup menu one item at a time. <PageUp> and
+			<PageDown> can be used to scroll a page of popup
+			window, while <C-F> and <C-B> can be used to scroll a
+			page of underlying window.  The <Esc> or <Ctrl-C> keys
+			can be used to cancel the popup menu.
 
 			If one or more keyword characters are typed, then only
 			the symbols containing the keyword characters are


### PR DESCRIPTION
Add 1 character padding to the sides of signature popup window. Otherise, the leftmost character of popup looks like continuation of line from underneath text in some colorschemes. A subtle improvemnt.

M  autoload/lsp/signature.vim