### PR TITLE
BUG: LspOmniFunc() throws E716

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -468,7 +468,6 @@ enddef
 
 # omni complete handler
 def g:LspOmniFunc(findstart: number, base: string): any
-
   var lspserver: dict<any> = buf.CurbufGetServerChecked('completion')
   if lspserver->empty()
     return -2

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -147,6 +147,7 @@ enddef
 # process the 'textDocument/completion' reply from the LSP server
 # Result: CompletionItem[] | CompletionList | null
 export def CompletionReply(lspserver: dict<any>, cItems: any)
+  lspserver.completeItemsIsIncomplete = false
   if cItems->empty()
     if lspserver.omniCompletePending
       lspserver.completeItems = []
@@ -154,8 +155,6 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
     endif
     return
   endif
-
-  lspserver.completeItemsIsIncomplete = false
 
   var items: list<dict<any>>
   if cItems->type() == v:t_list
@@ -469,6 +468,7 @@ enddef
 
 # omni complete handler
 def g:LspOmniFunc(findstart: number, base: string): any
+
   var lspserver: dict<any> = buf.CurbufGetServerChecked('completion')
   if lspserver->empty()
     return -2


### PR DESCRIPTION
In LspOmniFunc() when cItems is empty (when findstart=1) it does not set the key 'completeItemsIsIncomplete' in the lspserver dictionary. When LspOmniFunc is called again with findstart=0, it fails.
```
line   46:
E716: Key not present in Dictionary: "completeItemsIsIncomplete"
```
This affects rust, nix, and other lsp servers:
https://github.com/girishji/vimcomplete/issues/14

M  autoload/lsp/completion.vim