### PR TITLE
Improve popup window

### DIFF
--- a/autoload/lsp/hover.vim
+++ b/autoload/lsp/hover.vim
@@ -127,7 +127,6 @@ export def HoverReply(lspserver: dict<any>, hoverResult: any, cmdmods: string): 
 					   close: 'click',
 					   fixed: true,
 					   maxwidth: 80,
-					   minwidth: 80,
 					   border: [0, 1, 0, 1],
 					   borderchars: [' '],
 					   filter: HoverWinFilterKey})


### PR DESCRIPTION
Previously, popup window minwidth was set to 80. This means, if a popup window have text less than 80 character, it will keep some extra spaces until popup reaches 80 characters. For example:
![prev](https://github.com/yegappan/lsp/assets/77573476/6213b383-6b71-4665-a0cf-5fd9e5c8c2ec)

But keeping minwidth to default, removes those extra spaces and the popup window looks nicer.
![now](https://github.com/yegappan/lsp/assets/77573476/65d8b528-db14-4ea6-85c1-1e7aaca73feb)