### PR TITLE
bug: 'Lazy doc' completion broken for omnifunc

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -641,7 +641,7 @@ export def BufferInit(lspserver: dict<any>, bnr: number, ftype: string)
     return
   endif
 
-  if !opt.lspOptions.autoComplete && !LspOmniComplEnabled(ftype)
+  if !opt.lspOptions.autoComplete && !LspOmniComplEnabled(ftype) && !opt.lspOptions.omniComplete
     # LSP auto/omni completion support is not enabled for this buffer
     return
   endif


### PR DESCRIPTION
pylsp was not displaying documentation from lsp server. this fixes the problem.
user does not have to enable omnicomplete for each file type when main option omniComplete is already enabled.

M  autoload/lsp/completion.vim