### PR TITLE
Multiple server completion support

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -603,7 +603,6 @@ enddef
 # complete done handler (LSP server-initiated actions after completion)
 def LspCompleteDone(servId: number, bnr: number)
   var lspserver: dict<any> = buf.BufLspServerGetById(bnr, servId)
-    echomsg lspserver.name
     if lspserver->empty()
       return
     endif

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -10,7 +10,7 @@ fi
 
 VIM_CMD="$VIMPRG -u NONE -U NONE -i NONE --noplugin -N --not-a-term"
 
-TESTS="volar_tests.vim"
+TESTS="clangd_tests.vim tsserver_tests.vim gopls_tests.vim not_lspserver_related_tests.vim markdown_tests.vim rust_tests.vim"
 
 RunTestsInFile() {
   testfile=$1
@@ -42,7 +42,7 @@ for encoding in "utf-8" "utf-16" "utf-32"
 do
   export LSP_OFFSET_ENCODING=$encoding
   echo "LSP offset encoding: $LSP_OFFSET_ENCODING"
-  # RunTestsInFile clangd_offsetencoding.vim
+  RunTestsInFile clangd_offsetencoding.vim
 done
 
 echo "SUCCESS: All the tests passed."


### PR DESCRIPTION
- Working mult server compl
- Removed time measure prop
- Tweaked LspResolver to be server id dependent
- Fixed text complete server dependent
- Reset tests


# Purpose: Volar 2 support

Note, should propbably be tested by more people before being merged to main!

## Config
```json
{
      "name": "vue-ls",
      "filetype": ["vue"],
      "path": "vue-language-server",
      "args": ["--stdio"],
      "features": {
        "definition": true,
        "rename": true
      },
      "initializationOptions": {
          "typescript": {
              "tsdk": "../node/v20.11.0/lib/node_modules/typescript/lib"
          }
      },
    },
    {
      "name": "ts-ls",
      "filetype": ["typescript", "javascript", "vue"],
      "path": "typescript-language-server",
      "args": ["--stdio"],
      "features": {
        "documentFormatting": false,
        "definition": true,
        "rename": true
      },
      "initializationOptions": {
          "plugins":[
            {
              "name": "@vue/typescript-plugin",
              "location":".../node/v20.11.0/lib/node_modules/@vue/typescript-plugin",
              "languages": ["vue"]
            }
          ]
      }
   }
```
## Status: 
- [x] completions
    - [x] auto imports
- [x] diagnostics
- [ ] definitions (working in some cases, but not all)
- [ ] references 


