### PR TITLE
fix: ignore unsupported notification messages from tailwindcss-language-server

### DIFF
--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -132,6 +132,7 @@ export def ProcessNotif(lspserver: dict<any>, reply: dict<any>): void
       'o#/projectconfiguration',
       'o#/projectdiagnosticstatus',
       'o#/unresolveddependencies',
+      '@/tailwindCSS/projectInitialized'
     ]
 
   if lsp_notif_handlers->has_key(reply.method)


### PR DESCRIPTION
Yegappan plugin only support insiders version. 
My version: `@tailwindcss/language-server@0.0.0-insiders.81bfb90`
