### PR TITLE
Add multiple language server association with syntax elements

### DIFF
--- a/.github/workflows/unitests.yml
+++ b/.github/workflows/unitests.yml
@@ -12,23 +12,26 @@ jobs:
     steps:
       - name: Install packages
         run: |
-          sudo apt update
+          sudo apt-get update
           # install clangd language server
-          sudo apt install -y clangd-15
+          sudo apt-get install -y clangd-15
           # install nodejs
-          sudo apt install -y curl
+          sudo apt-get install -y curl
           curl -fsSL https://deb.nodesource.com/setup_18.x | sudo bash -
-          sudo apt install -y nodejs
+          sudo apt-get install -y nodejs
           # install the typescript language server
           sudo npm install -g typescript-language-server typescript
           # install the golang language server
-          sudo apt install -y golang
-          sudo apt install -y gopls
+          sudo apt-get install -y golang
+          sudo apt-get install -y gopls
           # install the rust language server
-          sudo apt install -y cargo rust-src
+          sudo apt-get install -y cargo rust-src
           mkdir -p ~/.local/bin
           curl -L https://github.com/rust-lang/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz | gunzip -c - > ~/.local/bin/rust-analyzer
           chmod +x ~/.local/bin/rust-analyzer
+          # install markdown language server
+          curl -L https://github.com/artempyanykh/marksman/releases/latest/download/marksman-linux-x64 -o ~/.local/bin/marksman
+          chmod +x ~/.local/bin/marksman
       - name: Setup Vim
         uses: rhysd/action-setup-vim@v1
         id: vim

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -693,6 +693,11 @@ export def AddServer(serverList: list<dict<any>>)
       server.runUnlessSearch = []
     endif
 
+    if !server->has_key('syntaxAssociatedLSP') ||
+	server.syntaxAssociatedLSP->type() != v:t_list
+      server.syntaxAssociatedLSP = []
+    endif
+
     var lspserver: dict<any> = lserver.NewLspServer(server)
 
     var ftypes = server.filetype

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1892,7 +1892,8 @@ export def NewLspServer(serverParams: dict<any>): dict<any>
     typeHierPopup: -1,
     workspaceConfig: serverParams.workspaceConfig->deepcopy(),
     workspaceSymbolPopup: -1,
-    workspaceSymbolQuery: ''
+    workspaceSymbolQuery: '',
+    syntaxAssociatedLSP: serverParams.syntaxAssociatedLSP->deepcopy(),
   }
   lspserver.logfile = $'lsp-{lspserver.name}.log'
   lspserver.errfile = $'lsp-{lspserver.name}.err'

--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -361,4 +361,8 @@ export def FindNearestRootDir(startDir: string, files: list<any>): string
   return sortedList[0]
 enddef
 
+export def ListSynstackNamesAtPoint(line: number, col: number): list<string>
+  return synstack(line, col)->map((_, v) => v->synIDattr('name'))
+enddef
+
 # vim: tabstop=8 shiftwidth=2 softtabstop=2

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1900,6 +1900,44 @@ everything else: >
 		},
 	])
 <
+Language servers can also be configured to associate themselves with specific
+syntax elements. If a syntax element is detected at the current location, the
+corresponding language server will take precedence over the standard ordering.
+
+To specify a language server for a particular syntax element, use the
+`syntaxAssociatedLSP` property in the configuration object passed to
+`LspAddServer`. The value of `syntaxAssociatedLSP` should be a string or list
+of strings representing the desired syntax elements.
+>
+	vim9script
+
+	# Add two LSP configurations for handling JavaScript, TypeScript, and
+	# GraphQL files.
+	g:LspAddServer([
+		{
+			# Configuration for Typescript-language-server:
+			# Used for general purposes when working with '.js'
+			# and '.ts' files.
+			filetype: ['javascript', ''typescript'],
+			path: 'typescript-language-server',
+			args: ['--stdio']
+		},
+		{
+			# Configuration for GraphQL-language-server:
+			# Specifically bound to 'graphqlTemplateString' syntax
+			# element. Will handle requests regarding GraphQL
+			# template literals.
+			filetype: ['javascript', ''typescript', 'graphql'],
+			path: 'graphql-lsp',
+			args: ['server', '-m', 'stream'],
+			syntaxAssociatedLSP: ['graphqlTemplateString'],
+		}
+	])
+
+<
+To discover the current syntax stack and determine the appropriate value for
+`syntaxAssociatedLSP`, you can employ `LspUtilGetCurrentSynStack` command. 
+
 ==============================================================================
 17. Language Server Features			*lsp-features*
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -13,6 +13,7 @@ endif
 g:loaded_lsp = true
 
 import '../autoload/lsp/options.vim'
+import '../autoload/lsp/util.vim'
 import autoload '../autoload/lsp/lsp.vim'
 
 # Set LSP plugin options from 'opts'.
@@ -105,6 +106,7 @@ command! -nargs=? -bar LspSymbolSearch lsp.SymbolSearch(<q-args>, <q-mods>)
 command! -nargs=1 -bar -complete=dir LspWorkspaceAddFolder lsp.AddWorkspaceFolder(<q-args>)
 command! -nargs=0 -bar LspWorkspaceListFolders lsp.ListWorkspaceFolders()
 command! -nargs=1 -bar -complete=dir LspWorkspaceRemoveFolder lsp.RemoveWorkspaceFolder(<q-args>)
+command! -nargs=0 -bar LspUtilGetCurrentSynStack echo util.ListSynstackNamesAtPoint(line('.'), col('.'))
 
 # Add the GUI menu entries
 if has('gui_running')

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -10,7 +10,7 @@ fi
 
 VIM_CMD="$VIMPRG -u NONE -U NONE -i NONE --noplugin -N --not-a-term"
 
-TESTS="clangd_tests.vim tsserver_tests.vim gopls_tests.vim not_lspserver_related_tests.vim markdown_tests.vim rust_tests.vim"
+TESTS="clangd_tests.vim tsserver_tests.vim gopls_tests.vim not_lspserver_related_tests.vim markdown_tests.vim rust_tests.vim syntax_stack_lsp_chooser_test.vim"
 
 RunTestsInFile() {
   testfile=$1

--- a/test/syntax_stack_lsp_chooser_test.vim
+++ b/test/syntax_stack_lsp_chooser_test.vim
@@ -1,0 +1,68 @@
+vim9script
+
+import '../autoload/lsp/buffer.vim' as buf
+import '../autoload/lsp/util.vim' as util
+
+source common.vim
+
+g:markdown_fenced_languages = ['c']
+
+var lspServers = [
+  {
+    name: 'marksman',
+    filetype: 'markdown',
+    path: (exepath('marksman') ?? expand('~') .. '/.local/bin/marksman'),
+    args: ['server'],
+  },
+  {
+    name: 'clangd',
+    filetype: 'markdown',
+    path: (exepath('clangd-15') ?? exepath('clangd')),
+    args: ['--background-index', '--clang-tidy'],
+    syntaxAssociatedLSP: ['markdownHighlight_c', 'markdownHighlightc'],
+
+  },
+]
+call LspAddServer(lspServers)
+
+def FillDummyFile()
+  :silent edit dummy.md
+  sleep 200m
+  var lines: list<string> =<< trim END
+    # Title
+ 
+    ```c
+    int f1() {
+      int x;
+      int y;
+      x = 1;
+      y = 2;
+      return x + y;
+    }
+    ```
+  END
+  setline(1, lines)
+enddef
+
+def g:Test_ChoseDefaultLspIfNoSyntaxMatch()
+  FillDummyFile()
+  search('Title')
+  var selected_lsp =  buf.BufLspServerGet(bufnr(), 'hover')
+  assert_true(selected_lsp->has_key('name'))
+  assert_equal(selected_lsp.name, 'marksman')
+enddef
+
+def g:Test_ChooseCorrectLspIfSyntaxMatch()
+  FillDummyFile()
+  search('int')
+  var selected_lsp =  buf.BufLspServerGet(bufnr(), 'hover')
+  assert_true(selected_lsp->has_key('name'))
+  assert_equal(selected_lsp.name, 'clangd')
+enddef
+
+# Only here to because the test runner needs it
+def g:StartLangServer(): bool
+  return true
+enddef
+
+# vim: shiftwidth=2 softtabstop=2 noexpandtab


### PR DESCRIPTION
Improve multi-language server support by enabling the selection of the appropriate LSP based on syntax stack elements using a new configuration option for the LSP: `syntaxAssociatedLSP`, which accepts a list of syntax names obtainable through:

```vim
synstack(line, col)->map((_, v) => v->synIDattr('name'))
```

This enhancement allows by example, the simultaneous use of a PHP and HTML LSP in a PHP file when an LSP function is triggered. If the syntax stack contains an `htmlTag` pattern, the HTML LSP is called; otherwise, the PHP LSP is utilized. Furthermore, this improvement supports cases like embedding GraphQL blocks in TypeScript files.

Example usages include situations like the following configurations:

```vim
    call LspAddServer([
                \{
                \    'name': 'phpactor',
                \    'filetype': ['php'],
                \    'path': expand('~') . '/.local/bin/phpactor',
                \    'args': ['language-server'],
                \},
                \{
                \    'name': 'htmlls',
                \    'filetype': ['html', 'php'],
                \    'path': l:lib_path . 'node_modules/.bin/html-languageserver',
                \    'args': ['--stdio'],
                \    'initializationOptions': {'embeddedLanguages': {'css': v:true, 'javascript': v:true}},
                \    'syntaxAssociatedLSP': ['htmlTag', 'htmlError'],
                \    'runUnlessSearch': [
                \      'angular.json',
                \    ],
                \},
                \{
                \    'name': 'typescript-language-server',
                \    'filetype': ['typescript', 'javascript'],
                \    'path': l:lib_path . '/node_modules/.bin/typescript-language-server',
                \    'args': ['--stdio'],
                \},
                \{
                \    'name': 'graphql-language-server',
                \    'filetype': ['typescript', 'javascript', 'graphql'],
                \    'path': l:lib_path . '/node_modules/.bin/graphql-lsp',
                \    'args': ['server', '-m', 'stream'],
                \    'initializationOptions': {'diagnostics': 'true'},
                \    'syntaxAssociatedLSP': ['graphqlTemplateString'],
                \},
                \])
```

While acknowledging that this approach is relatively straightforward, I believe it remains effective for conventional use cases as long as the language server is designed to operate within the context of the current file.