### PR TITLE
Unescape non-breaking spaces

### DIFF
--- a/autoload/lsp/markdown.vim
+++ b/autoload/lsp/markdown.vim
@@ -147,6 +147,8 @@ def Unescape(text: string, block_marker: string = ""): string
   result = result->substitute(' \@<! \=\n', ' ', 'g')
   # change hard line breaks
   result = result->substitute(' \{2,}\n', '\n', 'g')
+  # replace non-breaking spaces with spaces
+  result = result->substitute('&nbsp;', ' ', 'g')
   return result->substitute($'\\\({punctuation}\)', '\1', 'g')
 enddef
 

--- a/test/markdown_tests.vim
+++ b/test/markdown_tests.vim
@@ -267,7 +267,22 @@ def g:Test_Markdown()
 	[],
 	[{'col': 13, 'type': 'LspMarkdownCode', 'length': 15}]
       ]
-    ]
+    ],
+    [
+      # non-breaking space characters
+      # Input text
+      [
+	'&nbsp;&nbsp;This is text.',
+      ],
+      # Expected text
+      [
+	'  This is text.',
+      ],
+      # Expected text properties
+      [
+	[]
+      ]
+    ],
   ]
 
   var doc: dict<list<any>>


### PR DESCRIPTION
While using the Pyright lsp, I noticed some non-breaking space entities `&nbsp;` in the hover docs.

This update replaces the entities with spaces.

Requests - Before
![image](https://github.com/yegappan/lsp/assets/352985/b7d3ecdb-9151-4849-a5d4-c3a18df40396)

Requests  - After
![image](https://github.com/yegappan/lsp/assets/352985/48379049-c308-4a9b-b7f7-872db3e90161)

Textual - Before
![Screenshot from 2024-05-17 23-52-03](https://github.com/yegappan/lsp/assets/352985/9e063851-218a-4218-a178-429840dd6805)

Textual - After
![Screenshot from 2024-05-17 23-52-37](https://github.com/yegappan/lsp/assets/352985/c52ca168-f1ec-4d32-89e9-650ce849e56c)
