### PR TITLE
Fix crash with neocmakelsp + ale

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -355,7 +355,7 @@ def SendAleDiags(bnr: number, timerid: number)
              col: util.GetLineByteFromPos(bnr, v.range.start) + 1,
              end_lnum: v.range.end.line + 1,
              end_col: util.GetLineByteFromPos(bnr, v.range.end) + 1,
-             type: "EWIH"[v.severity - 1]}
+             type: "EWIH"[get(v, "severity", 3) - 1]}
     })
   )
 enddef


### PR DESCRIPTION
This fixes the following error by falling back to `info` severity:

```
Error detected while processing function <SNR>66_Output_cb[5]..lsp#handlers#ProcessMess
ages[32]..lsp#handlers#ProcessNotif[52]..<SNR>67_ProcessDiagNotif[2]..lsp#diag#DiagNoti
fication[72]..lsp#diag#ProcessNewDiags[5]..<SNR>69_SendAleDiags[14]..<lambda>46:
line    6:
E716: Key not present in Dictionary: "severity"
```
