### PR TITLE
Use a copy of the server list when restarting

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -543,7 +543,7 @@ enddef
 
 # Restart the LSP server for the current buffer
 def RestartServer()
-  var lspservers: list<dict<any>> = buf.CurbufGetServers()
+  var lspservers: list<dict<any>> = buf.CurbufGetServers()->copy()
   if lspservers->empty()
     util.WarnMsg($'No Lsp servers found for "{@%}"')
     return


### PR DESCRIPTION
If the original server list is used, it is cleared during the step of removing filetype buffers, so no servers are actually restarted, as the `lspservers` list is empty by the time the `for` loop is reached.

Fixes #378 