### PR TITLE
Fixed issue with clangd and textDocument/semanticTokens/full/delta

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -413,8 +413,14 @@ def Rpc(lspserver: dict<any>, method: string, params: any, handleError: bool = t
     lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Sent {req->string()}')
   endif
 
+  # Fixes issue where clangd will hang on textDocument/semanticTokens/full/delta
+  var timeout = 2000 # vim's default
+  if method == 'textDocument/semanticTokens/full/delta'
+    timeout = 100
+  endif
+
   # Do the synchronous RPC call
-  var reply = job->ch_evalexpr(req)
+  var reply = job->ch_evalexpr(req, {timeout: timeout})
 
   if lspserver.debug
     lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Received {reply->string()}')


### PR DESCRIPTION
Fixxed an issue where clangd would (sometimes) hang on textDocument/sematicTokens/full/delta. I'm not sure if there's a better way to handle it, as I'm not really sure why it's happening in the first place. If I have more time in the near future I'll look further into it. Got the same results on the tests with/without the fix, but some of the tests for clangd failed in both cases (which I'm guessing might be related to only having clangd-18 and not clangd-15 installed). Relevant issue: https://github.com/yegappan/lsp/issues/491