### PR TITLE
Add options to limit auto completion and buffer completion

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -182,7 +182,7 @@ export def CompletionReply(lspserver: dict<any>, cItems: any, trigger_type: numb
     snippet.CompletionVsnip(items)
   endif
 
-  if lspOpts.useBufferCompletion
+  if lspOpts.useBufferCompletion && count(lspOpts.bufferCompletionTriggers, trigger_type) > 0
     CompletionFromBuffer(items)
   endif
 

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -146,7 +146,7 @@ enddef
 
 # process the 'textDocument/completion' reply from the LSP server
 # Result: CompletionItem[] | CompletionList | null
-export def CompletionReply(lspserver: dict<any>, cItems: any)
+export def CompletionReply(lspserver: dict<any>, cItems: any, trigger_type: number)
   lspserver.completeItemsIsIncomplete = false
   if cItems->empty()
     if lspserver.omniCompletePending
@@ -549,7 +549,7 @@ def LspComplete()
   endif
 
   var [triggerKind, triggerChar] = GetTriggerAttributes(lspserver)
-  if triggerKind < 0
+  if count(opt.lspOptions.autoCompleteTriggers, triggerKind) == 0
     return
   endif
 

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -727,8 +727,11 @@ def GetCompletion(lspserver: dict<any>, triggerKind_arg: number, triggerChar: st
   #   interface CompletionContext
   params.context = {triggerKind: triggerKind_arg, triggerCharacter: triggerChar}
 
-  lspserver.rpc_a('textDocument/completion', params,
-			completion.CompletionReply)
+  # Wrap CompletionReply, so it gets the trigger kind
+  var CompletionReplyWithTriggerKind = (lspserverarg: dict<any>, cItems: any) =>
+    completion.CompletionReply(lspserverarg, cItems, triggerKind_arg)
+  echom lspserver.completionTriggerChars
+  lspserver.rpc_a('textDocument/completion', params, CompletionReplyWithTriggerKind)
 enddef
 
 # Get lazy properties for a completion item.

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -16,6 +16,15 @@ export var lspOptions: dict<any> = {
   # Otherwise, use omni-completion
   autoComplete: true,
 
+  # If autoComplete is set to true, limit auto completion to the specified cases:
+  # 1: typing keyword characters (see :help iskeyword)
+  # 2: typing a trigger character (language specific, provided by the lsp server.
+  #    E.g., for C++ this might be any of '.', '<', '>', ':', '"', '/', '*'
+  # Default is to execute autocompletion in both cases.  If you want autocompletion only when typing
+  # a trigger character, set this option to [ 2 ]. You can still use omni-completion to trigger
+  # completion manually in other situations.
+  autoCompleteTriggers: [ 1, 2 ],
+
   # In normal mode, highlight the current symbol automatically
   autoHighlight: false,
 

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -34,6 +34,14 @@ export var lspOptions: dict<any> = {
   # Automatically populate the location list with new diagnostics
   autoPopulateDiags: false,
 
+  # If useBufferCompletion is set to true, limit completion to the specified cases:
+  # 1: typing keyword characters (see :help iskeyword)
+  # 2: typing a trigger character (language specific, provided by the lsp server.
+  #    E.g., for C++ this might be any of '.', '<', '>', ':', '"', '/', '*'
+  # Default is to execute buffer completion in both cases. If you do not want buffer completions
+  # to come up with more specific completions (e.g., class members, file names), set it to [ 1 ].
+  bufferCompletionTriggers: [ 1, 2 ],
+
   # icase | fuzzy | case match for language servers that replies with a full
   # list of completion items
   completionMatcher: 'case',


### PR DESCRIPTION
Add option to limit usage of buffer/buffer completion

Auto completion can now be set to be triggered on specific trigger types. This is useful to auto-complete on trigger characters only, e.g. when typing a dot to access a class member, or a colon for a namespaced symbol. See documentation of option autoCompleteTriggers in options.vim.

When completing a file name or a class method, buffer completion makes the list longer and provides little value. The option bufferCompletionTriggers allows to turn buffer completion of for specific trigger types.

The first part (auto completion) was discussed in #553. I made the PR accordingly.