### PR TITLE
Do LspAttached autocmd in the buffer its actually called for

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -434,7 +434,7 @@ def BufferInit(lspserverId: number, bnr: number): void
     endfor
 
     if exists('#User#LspAttached')
-      doautocmd <nomodeline> User LspAttached
+      execute ':' .. bnr .. 'bufdo doautocmd <nomodeline> User LspAttached'
     endif
   endif
 enddef

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -434,7 +434,7 @@ def BufferInit(lspserverId: number, bnr: number): void
     endfor
 
     if exists('#User#LspAttached')
-      execute ':' .. bnr .. 'bufdo doautocmd <nomodeline> User LspAttached'
+      win_execute(bufwinnr(bnr), 'doautocmd <nomodeline> User LspAttached', silent)
     endif
   endif
 enddef


### PR DESCRIPTION
Issue: opening a session file with multiple buffers open would only set bufnr for the buffer that is focused from the start. This prevents buffer local mappings and autocmds from working properly.