### PR TITLE
let LS detect workspace root after first file opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ vim -u NONE -c "helptags $HOME/.vim/pack/downloads/opt/lsp/doc" -c q
 ```
 
 After installing the plugin using the above steps, add the following line to
-your $HOME/.vimrc file:
+your `$HOME/.vimrc` file:
 
 ```viml
 packadd lsp
@@ -55,41 +55,56 @@ To use the plugin features with a particular file type(s), you need to first reg
 The LSP servers are registered using the `LspAddServer()` function. This function accepts a list of LSP servers.
 
 To register a LSP server, add the following lines to your .vimrc file (use only the LSP servers that you need from the below list).  If you used [vim-plug](https://github.com/junegunn/vim-plug) to install the LSP plugin, the steps are described later in this section.
+
 ```viml
+vim9script
 
-" Clangd language server
-call LspAddServer([#{
-	\    name: 'clangd',
-	\    filetype: ['c', 'cpp'],
-	\    path: '/usr/local/bin/clangd',
-	\    args: ['--background-index']
-	\  }])
+g:lspServers = []
 
-" Javascript/Typescript language server
-call LspAddServer([#{
-	\    name: 'typescriptlang',
-	\    filetype: ['javascript', 'typescript'],
-	\    path: '/usr/local/bin/typescript-language-server',
-	\    args: ['--stdio'],
-	\  }])
+# Clangd language server
+g:lspServers->add({
+	name: 'clangd',
+	filetype: ['c', 'cpp'],
+	path: '/usr/local/bin/clangd',
+	args: ['--background-index']
+})
 
-" Go language server
-call LspAddServer([#{
-	\    name: 'golang',
-	\    filetype: ['go', 'gomod'],
-	\    path: '/usr/local/bin/gopls',
-	\    args: ['serve'],
-	\    syncInit: v:true
-	\  }])
+# Javascript/Typescript language server
+g:lspServers->add({
+	name: 'typescriptlang',
+	filetype: ['javascript', 'typescript'],
+	path: '/usr/local/bin/typescript-language-server',
+	args: ['--stdio'],
+})
 
-" Rust language server
-call LspAddServer([#{
-	\    name: 'rustlang',
-	\    filetype: ['rust'],
-	\    path: '/usr/local/bin/rust-analyzer',
-	\    args: [],
-	\    syncInit: v:true
-	\  }])
+# Go language server
+g:lspServers->add({
+	name: 'golang',
+	filetype: ['go', 'gomod'],
+	path: '/usr/local/bin/gopls',
+	args: ['serve'],
+	syncInit: true
+})
+
+# Rust language server
+g:lspServers->add({
+	name: 'rustlang',
+	filetype: ['rust'],
+	path: '/usr/local/bin/rust-analyzer',
+	args: [],
+	syncInit: true
+})
+
+# Only set Workspace Root once the first file of that file type is openend
+# otherwise often defaults to $HOME and scans too many files
+augroup LspSetup
+  autocmd!
+augroup END
+for i in range(len(g:lspServers))
+  for ft in g:lspServers[i].filetype
+    exe 'autocmd LspSetup FileType' ft 'autocmd BufWinEnter <buffer> call LspAddServer([g:lspServers[' .. i .. ']]) | autocmd! LspSetup FileType' ft
+  endfor
+endfor
 ```
 
 The above lines register the language servers for C/C++, Javascript/Typescript, Go and Rust file types.  Refer to the [Wiki](https://github.com/yegappan/lsp/wiki) page for various language server specific configuration.
@@ -110,6 +125,7 @@ The `LspAddServer()` function accepts a list of LSP servers with the above infor
 
 Some of the LSP plugin features can be enabled or disabled by using the `LspOptionsSet()` function, detailed in `:help lsp-options`.
 Here is an example of configuration with default values:
+
 ```viml
 call LspOptionsSet(#{
         \   aleSupport: v:false,
@@ -159,17 +175,25 @@ call LspOptionsSet(#{
 ```
 
 If you used [vim-plug](https://github.com/junegunn/vim-plug) to install the LSP plugin, then you need to use the LspSetup User autocmd to initialize the LSP server and to set the LSP server options.  For example:
+
 ```viml
 let lspOpts = #{autoHighlightDiags: v:true}
 autocmd User LspSetup call LspOptionsSet(lspOpts)
 
-let lspServers = [#{
+let g:lspServers = [#{
 	\	  name: 'clang',
 	\	  filetype: ['c', 'cpp'],
 	\	  path: '/usr/local/bin/clangd',
 	\	  args: ['--background-index']
 	\ }]
-autocmd User LspSetup call LspAddServer(lspServers)
+augroup LspSetup
+  autocmd!
+augroup END
+for i in range(len(g:lspServers))
+  for ft in g:lspServers[i].filetype
+    exe 'autocmd LspSetup FileType' ft 'autocmd BufWinEnter <buffer> call LspAddServer([g:lspServers[' .. i .. ']]) | autocmd! LspSetup FileType' ft
+  endfor
+endfor
 ```
 
 ## Supported Commands

--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ augroup LspSetup
 augroup END
 for i in range(len(g:lspServers))
   for ft in g:lspServers[i].filetype
-    exe 'autocmd LspSetup FileType' ft 'autocmd BufWinEnter <buffer> call LspAddServer([g:lspServers[' .. i .. ']]) | autocmd! LspSetup FileType' ft
+    exe 'autocmd LspSetup FileType' ft '++once'
+          \    'autocmd LspSetup BufWinEnter <buffer> ++once call LspAddServer([g:lspServers[' .. i .. ']])'
   endfor
 endfor
 ```

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -249,7 +249,8 @@ Shell script, Vim script and PHP file types: >
   augroup END
   for i in range(len(g:lspServers))
     for ft in g:lspServers[i].filetype
-      exe 'autocmd LspSetup FileType' ft 'autocmd BufWinEnter <buffer> call LspAddServer([g:lspServers[' .. i .. ']]) | autocmd! LspSetup FileType' ft
+      exe 'autocmd LspSetup FileType' ft '++once'
+          \ 'autocmd LspSetup BufWinEnter <buffer> ++once call LspAddServer([g:lspServers[' .. i .. ']])'
     endfor
   endfor
 <

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -183,7 +183,14 @@ LSP plugin, the steps are described later in this section: >
 			 args: ['--check-parent-process', '-v']
 		      }
 		   ]
-   LspAddServer(lspServers)
+    augroup LspSetup
+      autocmd!
+    augroup END
+    for i in range(len(g:lspServers))
+      for ft in g:lspServers[i].filetype
+        exe 'autocmd LspSetup FileType' ft 'autocmd BufWinEnter <buffer> call LspAddServer([g:lspServers[' .. i .. ']]) | autocmd! LspSetup FileType' ft
+      endfor
+    endfor
 <
 Depending on the location of the typescript and python pyls language servers
 installed in your system, update the "path" in the above snippet
@@ -237,7 +244,14 @@ Shell script, Vim script and PHP file types: >
 		        }
 		      }
 		   ]
-   LspAddServer(lspServers)
+  augroup LspSetup
+    autocmd!
+  augroup END
+  for i in range(len(g:lspServers))
+    for ft in g:lspServers[i].filetype
+      exe 'autocmd LspSetup FileType' ft 'autocmd BufWinEnter <buffer> call LspAddServer([g:lspServers[' .. i .. ']]) | autocmd! LspSetup FileType' ft
+    endfor
+  endfor
 <
 To add a language server, the following information is needed:
 
@@ -437,7 +451,14 @@ language server and to set the language server options.  For example: >
 		        args: ['--background-index']
 		      }
 		   ]
-    autocmd User LspSetup LspAddServer(lspServers)
+    augroup LspSetup
+      autocmd!
+    augroup END
+    for i in range(len(g:lspServers))
+      for ft in g:lspServers[i].filetype
+        exe 'autocmd LspSetup FileType' ft 'autocmd BufWinEnter <buffer> call LspAddServer([g:lspServers[' .. i .. ']]) | autocmd! LspSetup FileType' ft
+      endfor
+    endfor
 <
 						*lsp-options* *LspOptionsSet()*
 						*g:LspOptionsSet()*


### PR DESCRIPTION
Only set workspace root once the first file of that file type is opened; otherwise the workspace root often is `$HOME` or more generally different from the repo of the file (say when using Gvim, or generally opening a file in a Git repo different from the current work dir) and the LS scans too many files

Partially resolves [0] as ideally this workspace root would automatically change with the CWD, in particular after loading a session (`:h mksession`)

[0]: https://github.com/yegappan/lsp/issues/512