### PR TITLE
Remove check for 'isIncomplete' on completion

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -514,8 +514,7 @@ def g:LspOmniFunc(findstart: number, base: string): any
     var res: list<dict<any>> = lspserver.completeItems
     var prefix = lspserver.omniCompleteKeyword
 
-    # Don't attempt to filter on the items, when "isIncomplete" is set
-    if prefix->empty() || lspserver.completeItemsIsIncomplete
+    if prefix->empty()
       return res
     endif
 


### PR DESCRIPTION
Hi,
this remove the check for 'isComplete' when trying to do completion.

The main issue is that some lsps, such as rust analyzer (#366), will set this option and if the language server returns an unfiltered list, the user will receive completion completely unrelated to what they typed before.

### Before

[Screencast_20241103_002049.webm](https://github.com/user-attachments/assets/441be262-f63c-4e04-8073-3d137a6a7f4b)
 
### After

[Screencast_20241103_002234.webm](https://github.com/user-attachments/assets/adfa4f7e-021e-4e61-ba0a-536dcb5c793e)
