### PR TITLE
Add option to condense completion menu items (would address #581)

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -310,6 +310,26 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
     endif  
 
     d.user_data = item
+
+    # Condense completion menu items to single words (plus kind)
+    # Move all additional details to the info popup
+    # Caveat: LazyDoc will override moved details!
+    if lspOpts.condensedCompletionMenu
+      const SEP = (s) => empty(s) ? "" : "\n- - -\n"
+      var infoText = ''
+      if d->has_key('abbr') && len(d.abbr) > len(d.word)
+        infoText ..= SEP(infoText) .. '    ' .. d.abbr
+        d.abbr = d.word
+      endif
+      if d->has_key('menu') && !empty(d.menu)
+        infoText ..= SEP(infoText) .. '    ' .. d.menu
+        d.menu = ''
+      endif
+      if !lspserver.completionLazyDoc && !empty(infoText)
+        d.info = infoText .. (d->has_key('info') ? SEP(infoText) .. d.info : '')
+      endif
+    endif
+
     completeItems->add(d)
   endfor
 

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -143,6 +143,9 @@ export var lspOptions: dict<any> = {
 
   # Filter duplicate completion items
   filterCompletionDuplicates: false,
+
+  # Condenses the completion menu items to single (key-)words (plus kind)
+  condensedCompletionMenu: false,
 }
 
 # set the LSP plugin options from the user provided option values

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -684,6 +684,12 @@ filterCompletionDuplicates |Boolean| option. If enabled, duplicate completion
 			items sent from the server will be filtered to only
 			include one instance of the duplicates. 
 
+						*lsp-opt-condensedCompletionMenu*
+condensedCompletionMenu |Boolean| option. If enabled, minimizes completion 
+			menu items to single (key-) words (plus kind).
+			Moves all additional details to info popup.
+			Caveat: LazyDoc will override moved details!
+
 For example, to disable the automatic placement of signs for the LSP
 diagnostic messages, you can add the following line to your .vimrc file: >
 


### PR DESCRIPTION
This will add a new option `condensedCompletionMenu`, which allows to condense (or minimize) the text (width) of the completion menu items:
The default behavior for the completion menu items does not only display the word that will be completed but also additional details, like completion kind and detailed information, provided by the language LSP server. Typically, especially for typed languages for functions their call parameters with all their types are included. This makes the display of the completion menu items surprisingly overwhelming :smile: 
When this option new `condensedCompletionMenu` is enabled only the (key-) word and its kind is part of the completion menu item. The additional provided details from the LSP server are moved to the info popup, which is shown as soon as a completion item is selected.
This enhancement would address the issue:
 **Improve complete-popup on vertical screens #581**  https://github.com/yegappan/lsp/issues/581#issue-2748842834

Here is a screenshot of the default completion menu:
![2024-12-29_condensedComplMenu-false](https://github.com/user-attachments/assets/458300d7-f665-48e0-acb2-fc0f334cee20)


and here if this new option has been enabled:
![2024-12-29_condensedComplMenu-true png](https://github.com/user-attachments/assets/103f661e-ccfd-42cd-b6e6-6295fe9a3442)

Instead of sprinkling the necessary modifications all over the source code, I decided to collect them in one place, which maybe would be less efficient but would improve the readability of this enhancement.

 Caveat: For completion LazyDoc the detailed information which is moved to the info popup will be automatically overwritten with the lazily delivered documentation from the LSP server.

#581 