### PR TITLE
Fix completion item filtering condition

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -227,7 +227,7 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
       # snippet completion.  Needs a snippet plugin to expand the snippet.
       # Remove all the snippet placeholders
       d.word = MakeValidWord(d.word)
-    elseif !lspserver.completeItemsIsIncomplete || lspOpts.useBufferCompletion
+    elseif lspserver.completeItemsIsIncomplete || lspOpts.useBufferCompletion
       # Filter items only when "isIncomplete" is set (otherwise server would
       #   have done the filtering) or when buffer completion is enabled
 


### PR DESCRIPTION
I try to setup your LSP plugin for Rust using `rust-analyzer`, and I noticed that more results were shown in the completion menu. After diving into your code, I noticed that the following condition was not aligned with the comment just below. By removing the negation, it somehow filters properly the items. I am not sure about the consequences of such a change, but after the change it works as it was initially supposed to be.