### PR TITLE
Fix completion item label condition

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -194,8 +194,7 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
     # TODO: Add proper support for item.textEdit.newText and
     # item.textEdit.range.  Keep in mind that item.textEdit.range can start
     # way before the typed keyword.
-    if item->has_key('textEdit') &&
-	lspOpts.completionMatcherValue != opt.COMPLETIONMATCHER_FUZZY
+    if item->has_key('textEdit')
       var start_charcol: number
       if !prefix->empty()
 	start_charcol = charidx(starttext, start_idx) + 1


### PR DESCRIPTION
Related to #583.

When fuzzy completion is used, the wrong label is used when validating a completion item. For example, `rust-analyzer` could return `remove_dir (alias rmdir)` as a label, but `remove_dir` as next text (this late one should be used instead of the first one).

I'm not sure to understand why this section is restricted to non-fuzzy completion value matcher only. The label condition (either `item.textEdit.newText`, `item.insertText` or `item.label`) is useful no matter the completion matcher.