### PR TITLE
Support custom locations request

### DIFF
--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -191,4 +191,15 @@ export def CurbufGetServerChecked(feature: string = null_string): dict<any>
   return lspserver
 enddef
 
+export def CurbufGetServerByName(name: string): dict<any>
+  var lspservers: list<dict<any>> = CurbufGetServers()
+
+  for lspserver in lspservers
+    if lspserver.name == name
+      return lspserver
+    endif
+  endfor
+  return {}
+enddef
+
 # vim: tabstop=8 shiftwidth=2 softtabstop=2

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -833,9 +833,17 @@ export def ShowReferences(peek: bool)
 enddef
 
 # send custom locations request
-def g:FindLocations(peek: bool, method: string, args: dict<any> = {})
-  var lspserver: dict<any> = buf.CurbufGetServerChecked('references')
+def g:FindLocations(server_name: string, peek: bool, method: string, args: dict<any> = {})
+  var lspserver: dict<any> = buf.CurbufGetServerByName(server_name)
   if lspserver->empty()
+    return
+  endif
+  if !lspserver.running
+    util.ErrMsg($'Language server "{server_name}" is not running')
+    return
+  endif
+  if !lspserver.ready
+    util.ErrMsg($'Language server "{server_name}" is not ready')
     return
   endif
 

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -833,7 +833,7 @@ export def ShowReferences(peek: bool)
 enddef
 
 # send custom locations request
-def g:FindLocations(server_name: string, peek: bool, method: string, args: dict<any> = {})
+def g:LspFindLocations(server_name: string, peek: bool, method: string, args: dict<any> = {})
   var lspserver: dict<any> = buf.CurbufGetServerByName(server_name)
   if lspserver->empty()
     return

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -832,6 +832,16 @@ export def ShowReferences(peek: bool)
   lspserver.showReferences(peek)
 enddef
 
+# send custom locations request
+def g:FindLocations(peek: bool, method: string, args: dict<any> = {})
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('references')
+  if lspserver->empty()
+    return
+  endif
+
+  lspserver.findLocations(peek, method, args)
+enddef
+
 # highlight all the places where a symbol is referenced
 def g:LspDocHighlight(bnr: number = bufnr(), cmdmods: string = '')
   var lspserver: dict<any> = buf.CurbufGetServerChecked('documentHighlight')


### PR DESCRIPTION
This feature is for lsp server with custom locations request(e.g. [ccls](https://github.com/MaskRay/ccls)). It's similar to [CocLocations](https://github.com/neoclide/coc.nvim/blob/baac60ac1676cd5640648af9f07c15be24041a3e/doc/coc.txt#L783) in coc.nvim.

Example config for ccls
```vim
# not call
nmap <buffer> <localleader>f <scriptcmd>g:LspFindLocations('ccls', false, "textDocument/references", {"excludeRole": 32})<cr>
# macro
nmap <buffer> <localleader>M <scriptcmd>g:LspFindLocations('ccls', false, "textDocument/references", {"role": 64})<cr>
# read
nmap <buffer> <localleader>r <scriptcmd>g:LspFindLocations('ccls', false, "textDocument/references", {"role": 8})<cr>
# write
nmap <buffer> <localleader>w <scriptcmd>g:LspFindLocations('ccls', false, "textDocument/references", {"role": 16})<cr>
# x (xref)
# bases of up to 3 levels
nmap <buffer> <localleader>b <scriptcmd>g:LspFindLocations('ccls', false, "$ccls/inheritance", {})<cr>
nmap <buffer> <localleader>B <scriptcmd>g:LspFindLocations('ccls', false, "$ccls/inheritance", {"levels": 3})<cr>
# derived of up to 3 levels
nmap <buffer> <localleader>d <scriptcmd>g:LspFindLocations('ccls', false, "$ccls/inheritance", {"derived": v:true})<cr>
# derived of up to 3 levels
nmap <buffer> <localleader>D <scriptcmd>g:LspFindLocations('ccls', false, "$ccls/inheritance", {"derived": v:true, "levels": 3})<cr>
# caller
nmap <buffer> <localleader>c <scriptcmd>g:LspFindLocations('ccls', false, "$ccls/call")<cr>
# callee
nmap <buffer> <localleader>C <scriptcmd>g:LspFindLocations('ccls', false, "$ccls/call", {"callee": v:true})<cr>
# member
nmap <buffer> <localleader>m <scriptcmd>g:LspFindLocations('ccls', false, "$ccls/member")<cr>
``` 