### PR TITLE
Fix vsnip completion using signature trigger char

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -926,7 +926,7 @@ def ShowSignature(lspserver: dict<any>): void
 
   # interface SignatureHelpParams
   #   interface TextDocumentPositionParams
-  var params = lspserver.getTextDocPosition(false)
+  var params = lspserver.getTextDocPosition(true)
   lspserver.rpc_a('textDocument/signatureHelp', params,
 			signature.SignatureHelp)
 enddef

--- a/autoload/lsp/signature.vim
+++ b/autoload/lsp/signature.vim
@@ -61,7 +61,7 @@ export def BufferInit(lspserver: dict<any>)
     if ch =~ ' '
       mapChar = '<Space>'
     endif
-    exe $"inoremap <buffer> <silent> {mapChar} {mapChar}<C-R>=g:LspShowSignature()<CR>"
+    exe $"inoremap <expr> <buffer> <silent> {mapChar} complete_info()['selected'] != -1 ? '{mapChar}' : '{mapChar}\<C-O>:call g:LspShowSignature()\<CR>'"
   endfor
 
   # close the signature popup when leaving insert mode


### PR DESCRIPTION
This PR fixes an issue with vsnip snippet completion outputting `<Plug>(vsnip_integ:on_complete_done_after)` instead of the correct snippet after selecting a completion menu item using a signature trigger character.

To reproduce the issue:

- install plugins: 
    - hrsh7th/vim-vsnip
    - hrsh7th/vim-vsnip-integ
- set options:
    - `completionTextEdit: v:false`
    - `snippetSupport: v:true`
    - `vsnipSupport: v:true`
    - `showSignature: v:true`
- enter any text that shows the completion menu
- navigate to a menu item using <kbd>Ctrl</kbd> + <kbd>n</kbd>
- enter a signature trigger character (e.g. `(`)

The fix checks if a completion menu item is selected to determine whether to call the signature popup function along with the output of the signature trigger character.

The test `Test_LspShowSignature()` in `clangd_tests.vim` passes with the fix applied.

Before fix:


https://github.com/user-attachments/assets/eb15e0fb-29d4-438b-9c39-2e8697651f08



After fix:


https://github.com/user-attachments/assets/9d315834-86dd-4f86-8ddc-1763070c4b66


