### PR TITLE
docs(processDiagHandler): wrong order of args

### DIFF
--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -377,7 +377,7 @@ Additionally the following configurations can be made:
 			args: ['--stdio'],
 			processDiagHandler: (diags: list<dict<any>>) => {
 				# Only include errors and warnings
-				return diags->filter((diag, ix) => {
+				return diags->filter((ix, diag) => {
 					return diag.severity <= 2
 				})
 			},
@@ -392,7 +392,7 @@ Additionally the following configurations can be made:
 			path: '/usr/local/bin/typescript-language-server',
 			args: ['--stdio'],
 			processDiagHandler: (diags: list<dict<any>>) => {
-				return diags->map((diag, ix) => {
+				return diags->map((ix, diag) => {
 					diag.message = $'TypeScript: {diag.message}'
 					return diag
 				})


### PR DESCRIPTION
Current sample code as pasted will result in:
```
Error detected while processing function <SNR>73_Output_cb[5]..lsp#handlers#ProcessMessages[32]..lsp#handlers#ProcessNotif[52]..<SNR>74_ProcessDiagNotif[2]..lsp#diag#DiagNotification[24]..<lambda>31[5]..<lambda>32:
line    1:
E715: Dictionary required
```
Swapping the order corrects this issue.