### PR TITLE
open buffers from special windows in preview window

### DIFF
--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -286,7 +286,7 @@ export def JumpToLspLocation(location: dict<any>, cmdmods: string)
             # if the current buffer has unsaved changes and 'hidden' is not set,
             # or if the current buffer is a special buffer, then open the file
             # in a new window
-            exe $'belowright split {fname}'
+            exe $'pedit {fname}'
           else
             exe $'edit {fname}'
           endif


### PR DESCRIPTION
For example in the window shown after :LspIncomingCalls the openend references quickly become unreadable due to smaller and smaller splits; instead use the preview window to peek at them.

Prospectively use different mappings, say p for preview, o to open, to edit the buffer or open in a new split similar to @yssl 's' [0]

[0]: https://github.com/yssl/QFEnter?tab=readme-ov-file#usage