### PR TITLE
Configure Completion and SignatureHelp popups

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -41,6 +41,23 @@ var defaultKinds: dict<string> = {
   'Buffer':         'B',
 }
 
+export def InitOnce()
+  hlset([
+    {name: 'LspCompletionPopup', default: true, guibg: 'NONE', ctermbg: 'NONE'},
+    {name: 'LspCompletionPopupBorder', default: true, guibg: 'NONE', ctermbg: 'NONE'}
+  ])
+
+  if !exists('g:LspCompletionPopupBorderhighlight')
+    g:LspCompletionPopupBorderhighlight = ['LspCompletionPopupBorder']
+  endif
+  if !exists('g:LspCompletionPopupBorder')
+    g:LspCompletionPopupBorder = []
+  endif
+  if !exists('g:LspCompletionPopupBorderchars')
+    g:LspCompletionPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
+  endif
+enddef
+
 # Returns true if omni-completion is enabled for filetype "ftype".
 # Otherwise, returns false.
 def LspOmniComplEnabled(ftype: string): bool
@@ -441,6 +458,12 @@ def ShowCompletionDocumentation(cItem: any)
     var bufnr = id->winbufnr()
     id->popup_settext(infoText)
     infoKind->setbufvar(bufnr, '&ft')
+    id->popup_setoptions({
+      border: g:LspCompletionPopupBorder,
+      borderchars: g:LspCompletionPopupBorderchars,
+      borderhighlight: g:LspCompletionPopupBorderhighlight,
+      highlight: 'LspCompletionPopup'
+    })
     id->popup_show()
   else
     # &omnifunc with &completeopt =~ 'preview'

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -47,6 +47,7 @@ def LspInitOnce()
   prop_type_add('LspReadRef', {highlight: 'LspReadRef', override: override})
   prop_type_add('LspWriteRef', {highlight: 'LspWriteRef', override: override})
 
+  completion.InitOnce()
   diag.InitOnce()
   hover.InitOnce()
   inlayhints.InitOnce()

--- a/autoload/lsp/signature.vim
+++ b/autoload/lsp/signature.vim
@@ -38,7 +38,21 @@ def g:LspShowSignature(): string
 enddef
 
 export def InitOnce()
-  hlset([{name: 'LspSigActiveParameter', default: true, linksto: 'LineNr'}])
+  hlset([
+    {name: 'LspSigActiveParameter', default: true, linksto: 'LineNr'},
+    {name: 'LspSignatureHelpPopup', default: true, linksto: 'Pmenu'},
+    {name: 'LspSignatureHelpPopupBorder', default: true, guibg: 'NONE', ctermbg: 'NONE'}
+  ])
+
+  if !exists('g:LspSignatureHelpPopupBorderhighlight')
+    g:LspSignatureHelpPopupBorderhighlight = ['LspSignatureHelpPopupBorder']
+  endif
+  if !exists('g:LspSignatureHelpPopupBorder')
+    g:LspSignatureHelpPopupBorder = [0, 0, 0, 0]
+  endif
+  if !exists('g:LspSignatureHelpPopupBorderchars')
+    g:LspSignatureHelpPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
+  endif
 enddef
 
 # Initialize the signature triggers for the current buffer
@@ -136,7 +150,15 @@ export def SignatureHelp(lspserver: dict<any>, sighelp: any): void
     # Close the previous signature popup and open a new one
     lspserver.signaturePopup->popup_close()
 
-    var popupID = text->popup_atcursor({padding: [0, 1, 0, 1], moved: [col('.') - 1, 9999999], pos: 'botright'})
+    var popupID = text->popup_atcursor({
+      padding: [0, 1, 0, 1],
+      moved: [col('.') - 1, 9999999],
+      pos: 'botright',
+      border: g:LspSignatureHelpPopupBorder,
+      borderchars: g:LspSignatureHelpPopupBorderchars,
+      borderhighlight: g:LspSignatureHelpPopupBorderhighlight,
+      highlight: 'LspSignatureHelpPopup'
+    })
     var bnr: number = popupID->winbufnr()
     prop_type_add('signature', {bufnr: bnr, highlight: 'LspSigActiveParameter'})
     if hllen > 0

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1861,27 +1861,39 @@ The plugin provides the possibility to style popups according to one's liking.
 
 The following default options and highlight groups are provided: >
 
+	highlight LspCompletionPopup guibg=NONE ctermbg=NONE
+	highlight LspCompletionPopupBorder guibg=NONE ctermbg=NONE
+	let g:LspCompletionPopupBorderhighlight = ['LspCompletionPopupBorder']
+	let g:LspCompletionPopupBorder = []
+	let g:LspCompletionPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
+
 	highlight LspHoverPopup guibg=NONE ctermbg=NONE
 	highlight LspHoverPopupBorder guibg=NONE ctermbg=NONE
-	let g:LspHoverPopupBorderhighlight = ['LspHoverPopupBorder]
+	let g:LspHoverPopupBorderhighlight = ['LspHoverPopupBorder']
 	let g:LspHoverPopupBorder = []
 	let g:LspHoverPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
-	
+
 	highlight LspPeekPopup guibg=NONE ctermbg=NONE
 	highlight LspPeekPopupBorder guibg=NONE ctermbg=NONE
-	let g:LspPeekPopupBorderhighlight = ['LspPeekPopupBorder]
+	let g:LspPeekPopupBorderhighlight = ['LspPeekPopupBorder']
 	let g:LspPeekPopupBorder = []
 	let g:LspPeekPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
-	
+
 	highlight LspSymbolMenuPopup guibg=NONE ctermbg=NONE
 	highlight LspSymbolMenuPopupBorder guibg=NONE ctermbg=NONE
-	let g:LspSymbolMenuPopupBorderhighlight = ['LspSymbolMenuPopupBorder]
+	let g:LspSymbolMenuPopupBorderhighlight = ['LspSymbolMenuPopupBorder']
 	let g:LspSymbolMenuPopupBorder = []
 	let g:LspSymbolMenuPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
-	
+
+	highlight link LspSignatureHelpPopup Pmenu
+	highlight LspSignatureHelpPopupBorder guibg=NONE ctermbg=NONE
+	let g:LspSignatureHelpPopupBorderhighlight = ['LspSignatureHelpPopupBorder']
+	let g:LspSignatureHelpPopupBorder = [0, 0, 0, 0]
+	let g:LspSignatureHelpPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
+
 	highlight LspTypeHierarchyPopup guibg=NONE ctermbg=NONE
 	highlight LspTypeHierarchyPopupBorder guibg=NONE ctermbg=NONE
-	let g:LspTyperHierarchyPopupBorderhighlight = ['LspTyperHierarchyPopupBorder]
+	let g:LspTypeHierarchyPopupBorderhighlight = ['LspTyperHierarchyPopupBorder']
 	let g:LspTypeHierarchyPopupBorder = []
 	let g:LspTypeHierarchyPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
 <


### PR DESCRIPTION
This extends PR #620 with popup customization options for the completion popup and signature help popup.

The completion popup uses the same defaults as the other popups from #620. The signature help popups default to the current style (`Pmenu` highlight and no border) so will not be annoying to people who like the current, single line signature help look.