### PR TITLE
Add configuration for border of diagnostic popups.

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -117,6 +117,24 @@ export def InitOnce()
       }
     ])
   endif
+
+  hlset([
+    {name: 'LspDiagMsgPopup', default: true, guibg: 'NONE', ctermbg: 'NONE'},
+    {name: 'LspDiagMsgPopupBorder', default: true, guibg: 'NONE', ctermbg: 'NONE'},
+  ])
+
+  if !exists('g:LspDiagMsgPopupBorderhighlight')
+    g:LspDiagMsgPopupBorderhighlight = ['LspDiagMsgPopupBorder']
+  endif
+
+  if !exists('g:LspDiagMsgPopupBorder')
+    g:LspDiagMsgPopupBorder = []
+  endif
+
+  if !exists('g:LspDiagMsgPopupBorderchars')
+    g:LspDiagMsgPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
+  endif
+
 enddef
 
 # Initialize the diagnostics features for the buffer 'bnr'
@@ -615,10 +633,15 @@ def ShowDiagInPopup(diag: dict<any>)
   var msg = diag.message->split("\n")
   var msglen = msg->reduce((acc, val) => max([acc, val->strcharlen()]), 0)
 
-  var ppopts = {}
-  ppopts.pos = 'topleft'
-  ppopts.line = d.row + 1
-  ppopts.moved = 'any'
+  var ppopts = {
+      pos: 'topleft',
+      line: d.row + 1,
+      moved: 'any',
+      border: g:LspDiagMsgPopupBorder,
+      borderchars: g:LspDiagMsgPopupBorderchars,
+      borderhighlight: g:LspDiagMsgPopupBorderhighlight,
+      highlight: 'LspDiagMsgPopup',
+  }
 
   if msglen > &columns
     ppopts.wrap = true

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1897,6 +1897,12 @@ The following default options and highlight groups are provided: >
 	let g:LspTypeHierarchyPopupBorder = []
 	let g:LspTypeHierarchyPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
 <
+	highlight LspDiagMsgPopup guibg=NONE ctermbg=NONE
+	highlight LspDiagMsgPopupBorder guibg=NONE ctermbg=NONE
+	let g:LspDiagMsgPopupBorderhighlight = ['LspDiagMsgPopupBorder']
+	let g:LspDiagMsgPopupBorder = []
+	let g:LspDiagMsgPopupBorderchars = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
+
 Please refer to |popup_setoptions()| for more information.
 
 For styling the completion menu please refer to |hl-pmenu|.


### PR DESCRIPTION
This addition adds configurations options for the
border sizes and border characters of diagnostic
messages popups, which are shown with the command
:LspDiagnosticCurrent.