### PR TITLE
Adds the option ignoreCompleteItemsIsIncomplete.

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -178,7 +178,11 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
     items = cItems
   else
     items = cItems.items
-    lspserver.completeItemsIsIncomplete = cItems->get('isIncomplete', false)
+    if opt.lspOptions.ignoreCompleteItemsIsIncomplete->index(lspserver.name) >= 0
+      lspserver.completeItemsIsIncomplete = v:false
+    else
+      lspserver.completeItemsIsIncomplete = cItems->get('isIncomplete', false)
+    endif
   endif
 
   var lspOpts = opt.lspOptions

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -146,6 +146,9 @@ export var lspOptions: dict<any> = {
 
   # Condenses the completion menu items to single (key-)words (plus kind)
   condensedCompletionMenu: false,
+
+  # Ignore >ItemsIsIncomplete< messages from misbehaving servers:
+  ignoreCompleteItemsIsIncomplete: [],
 }
 
 # set the LSP plugin options from the user provided option values

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -691,6 +691,15 @@ condensedCompletionMenu |Boolean| option. If enabled, minimizes completion
 			Moves all additional details to info popup.
 			Caveat: LazyDoc will override moved details!
 
+					*lsp-opt-ignoreCompleteItemsIsIncomplete*
+ignoreCompleteItemsIsIncomplete |List of strings| option.
+			Optional list of LSP server names for which
+			'IsIncomplete' messages should be ignored and
+			filtering of received completion item lists
+			is enforced. This is helpful for LSP servers
+			that are misbehaving and always send this
+			kind of 'IsIncomplete' messages.
+
 For example, to disable the automatic placement of signs for the LSP
 diagnostic messages, you can add the following line to your .vimrc file: >
 


### PR DESCRIPTION
Optional list of LSP server names for which
'IsIncomplete' messages should be ignored and
filtering of received completion item lists
is enforced. This is helpful for LSP servers
that are misbehaving and always send this
kind of 'IsIncomplete' messages.