### PR TITLE
Combine LspSymbol prop types

### DIFF
--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -19,11 +19,11 @@ export def InitOnce()
     {name: 'LspSymbolRange', default: true, linksto: 'Visual'}
   ])
   prop_type_add('LspSymbolNameProp', {highlight: 'LspSymbolName',
-				       combine: false,
+				       combine: true,
 				       override: true,
 				       priority: 201})
   prop_type_add('LspSymbolRangeProp', {highlight: 'LspSymbolRange',
-				       combine: false,
+				       combine: true,
 				       override: true,
 				       priority: 200})
 enddef


### PR DESCRIPTION
This change allows base syntax-highlighting to bleed through the `LspSymbolName` and `LspSymbolName` highlights when using `:LspDocumentSymbol`:

```vim
colorscheme retrobox
hlset([
  {name: 'LspSymbolName', cterm: {bold: true}, guibg: '#303030'},
  {name: 'LspSymbolRange', cterm: {bold: true}, guibg: '#3c3836'}
])
```

Before:
![image](https://github.com/user-attachments/assets/9227c286-2058-4a87-8751-3cba5a120a8b)

After:
![image](https://github.com/user-attachments/assets/272f26d2-60ce-4545-914c-c4f6440ebb22)

I can't think of any downside to using `combine: true` but I may have missed something?