### PR TITLE
replace string() with json_encode() for logging

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -30,7 +30,7 @@ import './semantichighlight.vim'
 # LSP server standard output handler
 def Output_cb(lspserver: dict<any>, chan: channel, msg: any): void
   if lspserver.debug
-    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Received {msg->string()}')
+    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Received {msg->json_encode()}')
   endif
   lspserver.data = msg
   lspserver.processMessages()
@@ -351,7 +351,7 @@ def SendMessage(lspserver: dict<any>, content: dict<any>): void
   job->ch_sendexpr(content)
   if content->has_key('id')
     if lspserver.debug
-      lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Sent {content->string()}')
+      lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Sent {content->json_encode()}')
     endif
   endif
 enddef
@@ -408,14 +408,14 @@ def Rpc(lspserver: dict<any>, method: string, params: any, handleError: bool = t
   endif
 
   if lspserver.debug
-    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Sent {req->string()}')
+    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Sent {req->json_encode()}')
   endif
 
   # Do the synchronous RPC call
   var reply = job->ch_evalexpr(req)
 
   if lspserver.debug
-    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Received {reply->string()}')
+    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Received {reply->json_encode()}')
   endif
 
   if reply->has_key('result')
@@ -434,7 +434,7 @@ enddef
 # LSP server asynchronous RPC callback
 def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel, reply: dict<any>)
   if lspserver.debug
-    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Received {reply->string()}')
+    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Received {reply->json_encode()}')
   endif
 
   if reply->empty()
@@ -471,7 +471,7 @@ def AsyncRpc(lspserver: dict<any>, method: string, params: any, Cbfunc: func): n
   endif
 
   if lspserver.debug
-    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Sent {req->string()}')
+    lspserver.traceLog($'{strftime("%m/%d/%y %T")}: Sent {req->json_encode()}')
   endif
 
   # Do the asynchronous RPC call


### PR DESCRIPTION
If you're looking at log data, it is often helpful to view/process said logs with various tools (e.g jq). `json_encode()` (as opposed to `string()`) properly escape any needed characters, allow for quick and easy use by other tools.