### PR TITLE
Improve omnifunc responsiveness

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -539,9 +539,14 @@ def g:LspOmniFunc(findstart: number, base: string): any
     var res: list<dict<any>> = lspserver.completeItems
     var prefix = lspserver.omniCompleteKeyword
 
-    # Don't attempt to filter on the items, when "isIncomplete" is set
-    if prefix->empty() || lspserver.completeItemsIsIncomplete
+    if prefix->empty()
       return res
+    endif
+
+    # When "isIncomplete" is set, do not filter the items, and signal that Vim
+    # should request more items when user continues typing.
+    if lspserver.completeItemsIsIncomplete
+      return { words: res, refresh: 'always' }
     endif
 
     var lspOpts = opt.lspOptions


### PR DESCRIPTION
When "isIncomplete" is set, signal that Vim should request more items when user continues typing.

This is also relavent to the new `o` value in `complete` option for Ctrl_N completion.

LSP doc:
<img width="852" alt="Screenshot 2025-05-29 at 2 51 45 PM" src="https://github.com/user-attachments/assets/f7151901-8a16-460c-bacb-d174613fad5c" />

