### PR TITLE
Change LSP  shutdown-command parameter to 'v:null' instead of '{}'

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -219,7 +219,7 @@ enddef
 # Request: shutdown
 # Param: void
 def ShutdownServer(lspserver: dict<any>): void
-  lspserver.rpc('shutdown', {})
+  lspserver.rpc('shutdown', v:null)
 enddef
 
 # Send a 'exit' notification to the language server


### PR DESCRIPTION
According to the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown) the param value for the 'shutdown' request sent from the client
to the server should be 'none' not '{}'.

The current implementation of sending the value '{}' makes the LSP server [ty](https://github.com/astral-sh/ty) complain
about a JSON parsing failure:

```
Method: shutdown
    error: invalid type map, expected unit
```

**This fix has been tested successfully with the following LSP servers:**

- clangd
- rust-analyser
- gopls
- ruff
- ty
- jdtls


**Log & trace details:**

__lsp-ty.log:__

```
06/12/25 18:18:13: Sent {'method': 'shutdown', 'params': {}}
06/12/25 18:18:13: Received {'method': 'textDocument/publishDiagnostics', 'jsonr
pc': '2.0', 'params': {'diagnostics': [], 'uri': 'file:///home/temp/main.py'}}
06/12/25 18:18:13: Received {'method': 'window/showMessage', 'jsonrpc': '2.0', '
params': {'message': 'ty failed to handle a request from the editor. Check the l
ogs for more details.', 'type': 1}}
06/12/25 18:18:13: Received {'id': 2, 'jsonrpc': '2.0', 'error': {'code': -32603
, 'message': 'JSON parsing failure:^@Invalid request^@Method: shutdown^@ error:
invalid type: map, expected unit'}}
06/12/25 18:18:15: Received {}
```

__lsp-ty.err:__

```
  15.877270801s ERROR ty:main ty_server::server::api: Encountered error when routing request with ID 2: JSON parsing failure:
  Invalid request
  Method: shutdown
   error: invalid type: map, expected unit
     17.913496022s  WARN    main ty_server: Server shut down with an error: Received exit notification before a shutdown request
     ty failed
       Cause: Received exit notification before a shutdown request
```
