### PR TITLE
Use server name for show capabilities

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1786,7 +1786,7 @@ enddef
 # stage).
 def GetCapabilities(lspserver: dict<any>): list<string>
   var l = []
-  var heading = $"'{lspserver.path}' Language Server Capabilities"
+  var heading = $"'{lspserver.name}' Language Server Capabilities"
   var underlines = repeat('=', heading->len())
   l->extend([heading, underlines])
   for k in lspserver.caps->keys()->sort()


### PR DESCRIPTION
Some servers don't provide their own binary, e.g. pkl-lsp which is written in Java. In this case '/usr/bin/java' is shown before the server, which can be misleading.