### PR TITLE
Delay the LspAttached autocmd until entering the buffer

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -446,7 +446,13 @@ def BufferInit(lspserverId: number, bnr: number): void
     endfor
 
     if exists('#User#LspAttached')
-      doautocmd <nomodeline> User LspAttached
+      if bnr == bufnr()
+        doautocmd <nomodeline> User LspAttached
+      else
+        # Delay doautocmd until entering the buffer
+        execute 'autocmd LSPAutoCmds BufEnter <buffer=' .. bnr .. '>'
+              \ .. ' ++once doautocmd <nomodeline> User LspAttached'
+      endif
     endif
   endif
 enddef


### PR DESCRIPTION
For #641

When the buffer attached to the LSP is different from the current buffer, delay the LspAttached autocmd by registering `doautocmd <nomodeline> User LspAttached` to the `BufEnter` autocmd.
