### PR TITLE
Add full diagnostics to location-list

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -550,7 +550,8 @@ def DiagsUpdateLocList(bnr: number, calledByCmd: bool = false): bool
 		    end_lnum: d_end.line + 1,
                     end_col: util.GetLineByteFromPos(bnr, d_end) + 1,
 		    text: text,
-		    type: DiagSevToQfType(diag->get('severity', 1))})
+		    type: DiagSevToQfType(diag->get('severity', 1)),
+		    user_data: { diagnostic: diag }})
   endfor
 
   var op: string = ' '


### PR DESCRIPTION
This is just a small enhancement that adds the complete information of diagnostic messages
as `user_data` to location list entries. 
It works only in combination with the lsp-option `autoPopulateDiags`.

Of course this comes at the expense of additional memory usage!

Background: From time to time I'm experimenting with alternative UI's, i.e. which are not built
into this lsp library, for displaying diagnostic messages and for this I need access to most of the
information provided by the diagnostic messages which are unfortunately not included within
the standard location list entries.