### PR TITLE
Explicitly clear text properties before deleting lines to prevent Vim E340, E685

### DIFF
--- a/autoload/lsp/textedit.vim
+++ b/autoload/lsp/textedit.vim
@@ -202,6 +202,10 @@ export def ApplyTextEdits(bnr: number, text_edits: list<dict<any>>): void
   # We just need to be careful with all indices.
   appendbufline(bnr, finish_line + 1, lines[finish_line - start_line + 1 : -1])
   setbufline(bnr, start_line + 1, lines)
+
+  # Workaround for Vim issues #12568 & #18136
+  prop_clear(start_line + 1 + lines->len(), finish_line + 1, {'bufnr': bnr})
+
   deletebufline(bnr, start_line + 1 + lines->len(), finish_line + 1)
 
   if dellastline


### PR DESCRIPTION
Vim has issues when buffer lines are deleted, which have text properties assigned to them.

See:

- [internal errors after removing multiline text property](github.com/vim/vim/issues/12568)
- [Internal errors E340 E685 when buffer lines are deleted, which have text properties assigned](https://github.com/vim/vim/issues/18136)

This might even lead to segfaulting Vim.

Solution:
In order to prevent such an issue the text properties are explicitly cleared before the lines are deleted.


References:

[internal errors after removing multiline text property](github.com/vim/vim/issues/12568)
[Internal errors E340 E685 when buffer lines are deleted, which have text properties assigned](https://github.com/vim/vim/issues/18136)