### PR TITLE
Only apply `textEdit` offset when LSP column is less than cursor column

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -214,9 +214,9 @@ export def CompletionReply(lspserver: dict<any>, cItems: any)
 	textEditRange = textEdit.insert
       endif
       var textEditStartCol =
-		util.GetCharIdxWithoutCompChar(bufnr(), textEditRange.start)
-      if textEditStartCol != start_charcol
-	var offset = start_charcol - textEditStartCol - 1
+		util.GetCharIdxWithoutCompChar(bufnr(), textEditRange.start) + 1
+      if textEditStartCol < start_charcol
+	var offset = start_charcol - textEditStartCol
 	d.word = textEdit.newText[offset : ]
       else
 	d.word = textEdit.newText


### PR DESCRIPTION
I was having an issue with method/property completions in TypeScript. Pressing C-X C-O immediately after the dot worked, as did doing it after typing one or two characters after the dot. However completing something like `new Function().app` to "apply" didn't.

After some debugging, I realized that the text of the completion was getting mangled, so it no longer had the prefix the filter function was looking for. When the column reported by the language server is greater than the current cursor column, the offset calculated by the `textEdit` handler becomes negative, and `d.word` is set to the last few characters of `newText`. I think #161, which introduced the offset, was only meant to apply in cases where LSP column is less than cursor column.

I also looked into the reason this happens in the first place. typescript-language-server finds the dot accessor `.` or `?.` and tries to send a completion that includes it (presumably to allow tsserver to replace `.` with `?.`). It [calculates the range](https://github.com/typescript-language-server/typescript-language-server/blob/3e98d9b09344fca6846cafdac0da4f760d8cc6c3/src/lsp-server.ts#L538-L540) based on the current column and the length of the accessor. But, at the same time the completion is requested, it receives a `textDocument/didChange` notification replacing document contents with a shorter line, one that only includes the text up to the dot.

For example, when I type `new Function().app` and press C-X C-O, this is the document the language server receives (15 characters on that line):
```
new Function().
```

And the completion is requested with the starting position at character 17. So the length of the dot is 1, the starting position of the `textEdit` span is 17 - 1 = 16, which is greater than the column inside `CompletionReply`. Trying to find the text of the accessor it gets an empty string; the result is a correct `newText` not including the accessor dot and with a broken range.

The math typescript-language-server uses is wrong in that case, but I don't want to open an issue there, because I'm not sure this is a correct request from the LSP client. This PR doesn't fix the underlying problem, but it does work around the completions issue after `new Function().app` by removing a bug and leaving a not fully correct behavior in its place. Feel free to reject if it's too hacky.

(Apologies for the edits, I couldn't find the right PR to reference.)