### PR TITLE
Make semantic highlighting asynchronous

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -542,6 +542,9 @@ def SemanticHighlightUpdate(lspserver: dict<any>, bnr: number)
   # Send the pending buffer changes to the language server
   bnr->listener_flush()
 
+  # Capture the current changedtick
+  var requestTick = getbufvar(bnr, 'changedtick')
+
   var method = 'textDocument/semanticTokens/full'
   var params: dict<any> = {
     textDocument: {
@@ -560,13 +563,9 @@ def SemanticHighlightUpdate(lspserver: dict<any>, bnr: number)
     endif
   endif
 
-  var reply = lspserver.rpc(method, params)
-
-  if reply->empty() || reply.result->empty()
-    return
-  endif
-
-  semantichighlight.UpdateTokens(lspserver, bnr, reply.result)
+  lspserver.rpc_a(method, params, (_, reply) => {
+    semantichighlight.UpdateTokens(lspserver, bnr, reply, requestTick)
+  })
 enddef
 
 # Send a "workspace/didChangeConfiguration" notification to the language

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -127,6 +127,9 @@ export var lspOptions: dict<any> = {
   # Enable semantic highlighting
   semanticHighlight: false,
 
+  # Delay in milliseconds for semantic highlighting requests
+  semanticHighlightDelay: 1000,
+
   # Show diagnostic text in a balloon when the mouse is over the diagnostic
   showDiagInBalloon: true,
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -674,6 +674,12 @@ semanticHighlight	|Boolean| option.  Enables or disables semantic
 			highlighting.
 			By default this is set to false.
 
+					*lsp-opt-semanticHighlightDelay*
+semanticHighlightDelay	|Number| option.  Delay in milliseconds for semantic
+			highlighting requests. This prevents excessive
+			requests during rapid text changes.
+			By default this is set to 1000.
+
 						*lsp-opt-showDiagInBalloon*
 showDiagInBalloon	|Boolean| option.  When the mouse is over a range of
 			text referenced by a diagnostic, display the


### PR DESCRIPTION
Hi thanks for the plugin. I have been using this for a while now with a local patch to make semantic highlighting more usable, I cleaned up my patch and wanted to make it more official.

Mainly this changes semantic highlighting to async, as I found in practice most servers are quite slow to respond and it can cause noticable freezes in typing. The async requires some additional change detection logic using changetick to ensure highlights are applied to the correct version of the file (otherwise it results in a bunch of position errors from textprop).

I also added a timer to delay the request while typing to avoid sending too many requests.

Let me know what you think, thanks!