### PR TITLE
Silence 'Unsupported notification message' for lua-language-server

### DIFF
--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -132,7 +132,9 @@ export def ProcessNotif(lspserver: dict<any>, reply: dict<any>): void
       'o#/projectconfiguration',
       'o#/projectdiagnosticstatus',
       'o#/unresolveddependencies',
-      '@/tailwindCSS/projectInitialized'
+      '@/tailwindCSS/projectInitialized',
+      # lua-language-server sends a "hello world" message on start-up.
+      '$/hello'
     ]
 
   if lsp_notif_handlers->has_key(reply.method)


### PR DESCRIPTION
The lua-language-server LSP implementation sends a "hello world" message whenever it is started. Specifically, it sends: `{"jsonrpc":"2.0","method":"$/hello","params":["world"]}`.

This change simply adds the message to the list of ignored notifications to silence the resulting error when attaching this server to a lua file.