### PR TITLE
Allow bare omnicomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ call LspOptionsSet(#{
         \   diagVirtualTextWrap: 'default',
         \   noNewlineInCompletion: v:false,
         \   omniComplete: v:null,
+        \   omniCompleteAllowBare: v:false,
         \   outlineOnRight: v:false,
         \   outlineWinSize: 20,
         \   popupBorder: v:true,

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -501,7 +501,7 @@ def g:LspOmniFunc(findstart: number, base: string): any
   if findstart
 
     var [triggerKind, triggerChar] = GetTriggerAttributes(lspserver)
-    if triggerKind < 0
+    if triggerKind < 0 && !opt.lspOptions.omniCompleteAllowBare
       # previous character is not a keyword character or a trigger character,
       # so cancel omni completion.
       return -2
@@ -567,14 +567,14 @@ enddef
 
 # Insert mode completion handler. Used when 24x7 completion is enabled
 # (default).
-def LspComplete()
+export def LspComplete(force: bool = false)
   var lspserver: dict<any> = buf.CurbufGetServer('completion')
   if lspserver->empty() || !lspserver.running || !lspserver.ready
     return
   endif
 
   var [triggerKind, triggerChar] = GetTriggerAttributes(lspserver)
-  if triggerKind < 0
+  if triggerKind < 0 && !force
     return
   endif
 

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -83,6 +83,8 @@ export var lspOptions: dict<any> = {
 
   # Whether or not the omni-completion function can run even if there aren't
   # any characters that would normally trigger the completion.
+  # For backwards compatibility, and because this enables quirks like spaces
+  # being enough to trigger the completion popup, this is default-disabled. 
   omniCompleteAllowBare: false,
 
   # Open outline window on right side

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -81,6 +81,10 @@ export var lspOptions: dict<any> = {
   # set to null by default instead of false.
   omniComplete: null,
 
+  # Whether or not the omni-completion function can run even if there aren't
+  # any characters that would normally trigger the completion.
+  omniCompleteAllowBare: false,
+
   # Open outline window on right side
   outlineOnRight: false,
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -587,6 +587,13 @@ omniComplete		|Boolean| option. Enables or disables omni-completion.
 			default.  By setting "omniComplete" option to v:false,
 			omni-completion can also be disabled.
 
+						*lsp-opt-omniCompleteAllowBare*
+omniCompleteAllowBare   |Boolean| option. Defines whether or not the
+			omniComplete function can trigger even if there are no
+			characters in front of the cursor. Only takes effect if
+			|lsp-opt-omniComplete| is true. By default, this is set
+			to v:false.
+
 						*lsp-opt-outlineOnRight*
 outlineOnRight		|Boolean| option.  Open the outline window on the
 			right side, by default this is false.

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -8,26 +8,27 @@ Last change: Sep 8, 2025
 ==============================================================================
 CONTENTS                                                     *lsp-contents*
 
-     1. Overview ................................. |lsp-overview|
-     2. Requirements ............................. |lsp-installation|
-     3. Usage .................................... |lsp-usage|
-     4. Configuration............................. |lsp-configuration|
-     5. Commands ................................. |lsp-commands|
-     6. Insert Mode Completion ................... |lsp-ins-mode-completion|
-     7. Diagnostics .............................. |lsp-diagnostics|
-     8. Tag Function ............................. |lsp-tagfunc|
-     9. LSP Formatting ........................... |lsp-format|
-    10. Call Hierarchy ........................... |lsp-call-hierarchy|
-    11. Autocommands ............................. |lsp-autocmds|
-    12. Highlight Groups ......................... |lsp-highlight-groups|
-    13. Debugging ................................ |lsp-debug|
-    14. Custom Command Handlers .................. |lsp-custom-commands|
-    15. Custom LSP Completion Kinds .............. |lsp-custom-kinds|
-    16. Custom Popup Styles ...................... |lsp-custom-popup-styles|
-    17. Custom Locations Request ................. |lsp-custom-locations|
-    18. Multiple Language Servers for a buffer ... |lsp-multiple-servers|
-    19. Language Servers Features ................ |lsp-features|
-    20. License .................................. |lsp-license|
+     1. Overview ................................... |lsp-overview|
+     2. Requirements ............................... |lsp-installation|
+     3. Usage ...................................... |lsp-usage|
+     4. Configuration............................... |lsp-configuration|
+     5. Commands ................................... |lsp-commands|
+     6. Insert Mode Completion ..................... |lsp-ins-mode-completion|
+       6.1. Forcing completion without characters .. |lsp-ins-force|
+     7. Diagnostics ................................ |lsp-diagnostics|
+     8. Tag Function ............................... |lsp-tagfunc|
+     9. LSP Formatting ............................. |lsp-format|
+    10. Call Hierarchy ............................. |lsp-call-hierarchy|
+    11. Autocommands ............................... |lsp-autocmds|
+    12. Highlight Groups ........................... |lsp-highlight-groups|
+    13. Debugging .................................. |lsp-debug|
+    14. Custom Command Handlers .................... |lsp-custom-commands|
+    15. Custom LSP Completion Kinds ................ |lsp-custom-kinds|
+    16. Custom Popup Styles ........................ |lsp-custom-popup-styles|
+    17. Custom Locations Request ................... |lsp-custom-locations|
+    18. Multiple Language Servers for a buffer ..... |lsp-multiple-servers|
+    19. Language Servers Features .................. |lsp-features|
+    20. License .................................... |lsp-license|
 
 ==============================================================================
 1. Overview					*lsp-overview*
@@ -590,9 +591,15 @@ omniComplete		|Boolean| option. Enables or disables omni-completion.
 						*lsp-opt-omniCompleteAllowBare*
 omniCompleteAllowBare   |Boolean| option. Defines whether or not the
 			omniComplete function can trigger even if there are no
-			characters in front of the cursor. Only takes effect if
-			|lsp-opt-omniComplete| is true. By default, this is set
-			to v:false.
+			trigger characters in front of the cursor. Only takes
+			effect if |lsp-opt-omniComplete| is true. By default,
+			this is set to v:false.
+			Note that for implementation reasons, this can be a
+			very noisy option, as it'll cause omnicomplete to
+			trigger on spaces, as well as many other places where
+			it does not make sense.  For an equivalent and much
+			less noisy |lsp-opt-autoComplete| solution, see
+			|lsp-ins-force|
 
 						*lsp-opt-outlineOnRight*
 outlineOnRight		|Boolean| option.  Open the outline window on the
@@ -1511,6 +1518,25 @@ The process works as follows:
 7. To proceed with the second invocation of g:LspOmniFunc, it is crucial to
    ensure that |g:LspOmniCompletePending| returns false, indicating that the
    language server is now ready to provide the completion matches.
+
+------------------------------------------------------------------------------
+6.1. Forcing completion without characters		*lsp-ins-force*
+
+Using a custom mapping that calls the 24x7 completion function, you can force
+the completion dialog to appear even without any trigger characters. This can
+be especially useful in languages where there are well-defined things that
+could be inserted, but there's no special trigger characters that can be used
+first. For example when filling in TypeScript objects, and you want
+completions for the names without typing anything first.
+
+This is not enabled by default, as it can be relatively noisy under certain
+circumstances.
+
+Example mapping: >
+    inoremap <C-space> <C-\><C-o>:call lsp#completion#LspComplete(v:true)<cr>
+<
+(Note that <C-space> in particular is limited to gVim due to input limitations
+of terminal Vim)
 
 ==============================================================================
 7. Diagnostics						*lsp-diagnostics*


### PR DESCRIPTION
This PR adds support for forcing broader completions with both omnicomplete and 24x7 completion. 

Note that the omnicomplete solution isn't great, because there's no direct way to specify more granular triggers. This is mainly a problem if `set complete+=o`, but shouldn't be noticeable elsewhere as long as the trigger is exclusively manual. Both the force options are opt-in, and have two different methods. 24x7 completion currently goes via the `LspComplete` function, where a `force` option that defaults to false was added. This probably isn't optimal. I'm not sure if another API for end-users is better, but this can be dealt with in review. It should be opt-in, however, as if it defaults to true, it'll suffer from the same problems as omnicomplete, but by default and for everyone.

Omnicomplete has a global option set, because there's (AFAIK) no way to tell if an individual invocation of the omnicomplete function is a manual, forced request, so no equivalent to the new `force` variable for `LspComplete` exists. The new `omniCompleteAllowBare` `lspOption` acts as the opt-in for this. 

Autocomplete works with a mapping to the effect of
```
inoremap <C-space> <C-\><C-o>:call lsp#completion#LspComplete(v:true)<cr>
```

With autocomplete:
<img width="1156" height="272" alt="image" src="https://github.com/user-attachments/assets/f903d4ea-0ced-4ec3-b182-79df43147936" />

With omnicomplete:
<img width="1045" height="289" alt="image" src="https://github.com/user-attachments/assets/31e49a42-8f1d-4202-bfc0-c6f82b984b09" />


Closes #613