### PR TITLE
Fix #667: LspDocumentSymbol doesn't properly ignore user mappings

### DIFF
--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -987,6 +987,7 @@ def SymbolPopupMenu(symbolTable: list<dict<any>>)
   endif
   var symInputPopup = popup_create('', symInputPopupAttrs)
   var symPopupMenu = popup_menu(symNames, symNamesPopupAttrs)
+  feedkeys("\<CursorHold>", 'n') # fix issue with user mappings, see #667
 
   # Save the state in the popup menu window variables
   setwinvar(symPopupMenu, 'symbolTable', symbolTable)


### PR DESCRIPTION
Generating `CursorHold` event after popups were created fixes the issue with user mappings.