### PR TITLE
Revert PR 634: Avoid repeated `refresh:true` completion requests due to performance issues

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -539,14 +539,9 @@ def g:LspOmniFunc(findstart: number, base: string): any
     var res: list<dict<any>> = lspserver.completeItems
     var prefix = lspserver.omniCompleteKeyword
 
-    if prefix->empty()
+    # Don't attempt to filter on the items, when "isIncomplete" is set
+    if prefix->empty() || lspserver.completeItemsIsIncomplete
       return res
-    endif
-
-    # When "isIncomplete" is set, do not filter the items, and signal that Vim
-    # should request more items when user continues typing.
-    if lspserver.completeItemsIsIncomplete
-      return { words: res, refresh: 'always' }
     endif
 
     var lspOpts = opt.lspOptions


### PR DESCRIPTION
Revert https://github.com/yegappan/lsp/pull/634

The reverted change introduced performance regressions. Language servers such as **clangd** may return incomplete completion lists when under load. Continuously reissuing completion requests with `refresh:true` on every keystroke forces the server to recompute results repeatedly, which can significantly degrade responsiveness.

By reverting, we restore the previous behavior and avoid excessive, redundant calls that negatively impact performance.

This change impacts omnifunc only.

@yegappan please merge this asap.