### PR TITLE
signature: Show signature help only in insert mode

### DIFF
--- a/autoload/lsp/signature.vim
+++ b/autoload/lsp/signature.vim
@@ -42,7 +42,10 @@ export def InitOnce()
 enddef
 
 def LspShowSignatureCb(timer: number)
-  call g:LspShowSignature()
+  # Show signature only in insert mode
+  if mode() == 'i'
+    call g:LspShowSignature()
+  endif
 enddef
 
 # Initialize the signature triggers for the current buffer


### PR DESCRIPTION
Without this check, the signature help is also triggered when pressing K when hovering.