### PR TITLE
Add CodeAction resolve support (#674)

### DIFF
--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -219,11 +219,16 @@ export def ProcessServerCaps(lspserver: dict<any>, caps: dict<any>)
   if lspserver.caps->has_key('codeActionProvider')
     if lspserver.caps.codeActionProvider->type() == v:t_bool
       lspserver.isCodeActionProvider = lspserver.caps.codeActionProvider
+      lspserver.isCodeActionResolveProvider = v:false
     else
       lspserver.isCodeActionProvider = true
+      if lspserver.caps.codeActionProvider->type() == v:t_dict
+        lspserver.isCodeActionResolveProvider = lspserver.caps.codeActionProvider.resolveProvider
+      endif
     endif
   else
     lspserver.isCodeActionProvider = false
+    lspserver.isCodeActionResolveProvider = v:false
   endif
 
   # codeLensProvider
@@ -346,7 +351,11 @@ export def GetClientCaps(): dict<any>
 	  }
 	},
 	isPreferredSupport: true,
-	disabledSupport: true
+	disabledSupport: true,
+        dataSupport: true,
+        resolveSupport: {
+          properties: ['edit', 'command']
+        }
       },
       codeLens: {
 	dynamicRegistration: false

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1558,6 +1558,25 @@ def CodeLens(lspserver: dict<any>, fname: string)
   codelens.ProcessCodeLens(lspserver, bnr, reply.result)
 enddef
 
+#
+# Request: "codeAction/resolve"
+# Param: CodeAction
+def ResolveCodeAction(lspserver: dict<any>,
+		      codeAction: dict<any>): dict<any>
+  if !lspserver.isCodeActionResolveProvider
+    return {}
+  endif
+
+  var reply = lspserver.rpc('codeAction/resolve', codeAction)
+  if reply->empty()
+    return {}
+  endif
+
+  var codeActionItem: dict<any> = reply.result
+
+  return codeActionItem
+enddef
+
 # Request: "codeLens/resolve"
 # Param: CodeLens
 def ResolveCodeLens(lspserver: dict<any>, bnr: number,
@@ -2008,6 +2027,7 @@ export def NewLspServer(serverParams: dict<any>): dict<any>
     renameSymbol: function(RenameSymbol, [lspserver]),
     codeAction: function(CodeAction, [lspserver]),
     codeLens: function(CodeLens, [lspserver]),
+    resolveCodeAction: function(ResolveCodeAction, [lspserver]),
     resolveCodeLens: function(ResolveCodeLens, [lspserver]),
     workspaceQuery: function(WorkspaceQuerySymbols, [lspserver]),
     addWorkspaceFolder: function(AddWorkspaceFolder, [lspserver]),


### PR DESCRIPTION
This adds support for resolving the `edit` and `command` properties of `CodeAction` objects.

Tested as working with OmniSharp (see #674). Tested as not breaking rust-analyzer.