### PR TITLE
Fix LazyDoc in omnifunc completion

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -600,6 +600,8 @@ def LspResolve()
 	ShowCompletionDocumentation(item.user_data)
       endif
   endif
+
+  LspSetPopupFileType()
 enddef
 
 # Configure the non-lazy documentation popup
@@ -609,6 +611,8 @@ def LspCompleteConfigurePopup()
     return
   endif
   id->popup_setoptions(opt.PopupConfigure('Completion', {}))
+
+  LspSetPopupFileType()
 enddef
 
 # If the completion popup documentation window displays "markdown" content,
@@ -725,13 +729,6 @@ export def BufferInit(lspserver: dict<any>, bnr: number, ftype: string)
                 group: 'LSPBufferAutocmds',
                 cmd: 'LspCompleteConfigurePopup()'})
   endif
-
-  acmds->add({bufnr: bnr,
-	      # Don't replace CompleteChanged that was assigned above
-	      replace: false,
-	      event: 'CompleteChanged',
-	      group: 'LSPBufferAutocmds',
-	      cmd: 'LspSetPopupFileType()'})
 
   # Execute LSP server initiated text edits after completion
   acmds->add({bufnr: bnr,


### PR DESCRIPTION
When using the `rust-analyzer` LSP, omnicompletion doesn't show any documentation, only the `Lazy doc` text:

https://github.com/user-attachments/assets/3d7e4e23-dca6-4d82-84c1-ebd86ae5091c

This issue doesn't appear in some other LSPs, such as `gopls`.

With a few debug logs, I found that `LspResolve()` is never called: because the `LspSetPopupFileType()` autocommand (assigned later) has a `replace: true`.
The `LspResolve()` handler for `CompleteChanged` is then removed and replaced with `LspSetPopupFileType()`.

The changes fixed the issue for me:

https://github.com/user-attachments/assets/ad4e8b0e-f814-4d08-9f90-87f5ef514550
