### PR TITLE
Skip popup buffers

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -531,6 +531,12 @@ export def AddFile(bnr: number): void
     return
   endif
 
+  # Skip popup buffers (maybe just skip all special buffers?)
+  var buftype: string = bnr->getbufvar('&buftype')
+  if buftype ==# 'popup'
+    return
+  endif
+
   var ftype: string = bnr->getbufvar('&filetype')
   if ftype->empty()
     return


### PR DESCRIPTION
Don't automatically start servers for popup buffers, they cannot be entered like other Vim buffers, and may be used to preview files, by fuzzy finder plugins that include a preview window for example.

Fuzzbox and LeaderF both use the filetypedetect autocmd to detect the filetype and enable syntax highlighting in the preview window. Vim-Clap avoids this by parsing the output of `:autocmd filetypedetect` and using it to set &syntax, which is quite neat, but also seems unreliable.

Skipping popup buffers seems pretty uncontroversial to me, they cannot be entered like other Vim buffers, so enabling a language server in a popup seems to serve no purpose. I'd like to go further here and just skip all special buffers, (Fuzzbox, LeaderF, and Vim-Clap currently set preview window buftype to nofile), but I'm unsure of the side-effects.

Related to #661