### PR TITLE
Ignore activeParameter when sig has no params

### DIFF
--- a/autoload/lsp/signature.vim
+++ b/autoload/lsp/signature.vim
@@ -130,29 +130,29 @@ export def SignatureHelp(lspserver: dict<any>, sighelp: any): void
     if params_len > 0
       var activeParam: number = sighelp.activeParameter
       if activeParam < params_len
-        var paramInfo: dict<any> = params[activeParam]
-        var label: any = paramInfo.label
-        if label->type() == v:t_string
-          # label string
-          var label_str: string = label
-          hllen = label_str->len()
-          startcol = text->stridx(label_str)
-        else
-          # [inclusive start offset, exclusive end offset]
-          var label_offset: list<number> = params[activeParam].label
-          var start_offset: number = label_offset[0]
-          var end_offset: number = label_offset[1]
+	var paramInfo: dict<any> = params[activeParam]
+	var label: any = paramInfo.label
+	if label->type() == v:t_string
+	  # label string
+	  var label_str: string = label
+	  hllen = label_str->len()
+	  startcol = text->stridx(label_str)
+	else
+	  # [inclusive start offset, exclusive end offset]
+	  var label_offset: list<number> = params[activeParam].label
+	  var start_offset: number = label_offset[0]
+	  var end_offset: number = label_offset[1]
 
-          if has('patch-9.0.1629')
-            # Convert UTF-16 offsets
-            startcol = text->byteidx(start_offset, true)
-            var endcol: number = text->byteidx(end_offset, true)
-            hllen = endcol - startcol
-          else
-            startcol = start_offset
-            hllen = end_offset - start_offset
-          endif
-        endif
+	  if has('patch-9.0.1629')
+	    # Convert UTF-16 offsets
+	    startcol = text->byteidx(start_offset, true)
+	    var endcol: number = text->byteidx(end_offset, true)
+	    hllen = endcol - startcol
+	  else
+	    startcol = start_offset
+	    hllen = end_offset - start_offset
+	  endif
+	endif
       endif
     endif
   endif


### PR DESCRIPTION
Allow for null or otherwise invalid activeParameter in signatureHelp when the signature has no parameters. This seems to be allowed by the LSP spec which says the active parameter should be ignored if the active signature has no parameters.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureHelp

This fixes an issue using jedi-language-server, as it responds with an activeParameter value null when parameters is empty, causing this error every time SignatureHelp() is called for a function with no params:

Error detected while processing function <SNR>32_AsyncRpcCb[20]..lsp#signature#SignatureHelp:
line   23:
E1012: Type mismatch; expected number but got special

prabirshrestha/vim-lsp also allows for null values here, so does not throw an error when jedi-language-server returns a null activeParameter along with an empty parameters array