### PR TITLE
Update configs, snippetSupport for JSON completion

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -789,6 +789,8 @@ call LspAddServer([#{name: 'vscode-json-server',
                  \   args: ['--stdio'],
                  \ }])
 ```
+_Note_: The JSON language server supports code completion only if the _snippetSupport_ option is enabled.
+```
 
 <a name="vscode-markdown-lsp"/></a>
 ## VS Code Markdown Language Server


### PR DESCRIPTION
Update example configs, note that client capability `snippetSupport` is required for code completion using JSON language server.

Format of note copied from same for CSS language server