### PR TITLE
Update modelines to be consistent in project files

### DIFF
--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -202,4 +202,4 @@ export def CurbufGetServerByName(name: string): dict<any>
   return {}
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/callhierarchy.vim
+++ b/autoload/lsp/callhierarchy.vim
@@ -191,4 +191,4 @@ export def OutgoingCalls(lspserver: dict<any>)
   CallHierarchyTreeShow(false, prepareReply, reply)
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -520,4 +520,4 @@ export def GetClientCaps(): dict<any>
   return clientCaps
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/codeaction.vim
+++ b/autoload/lsp/codeaction.vim
@@ -148,4 +148,4 @@ export def ApplyCodeAction(lspserver: dict<any>, actionlist: list<dict<any>>, qu
   HandleCodeAction(lspserver, actions[choice - 1])
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/codelens.vim
+++ b/autoload/lsp/codelens.vim
@@ -29,4 +29,4 @@ export def ProcessCodeLens(lspserver: dict<any>, bnr: number, codeLensItems: lis
   codeaction.DoCommand(lspserver, codeLensItems[choice - 1].command)
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -749,4 +749,4 @@ export def BufferLoadedInWin(bnr: number)
   endif
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -929,4 +929,4 @@ export def LspDiagsOptionsChanged()
   endif
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -342,4 +342,4 @@ export def ProcessMessages(lspserver: dict<any>): void
   endif
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/hover.vim
+++ b/autoload/lsp/hover.vim
@@ -147,4 +147,4 @@ export def HoverReply(lspserver: dict<any>, hoverResult: any, cmdmods: string): 
   endif
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/inlayhints.vim
+++ b/autoload/lsp/inlayhints.vim
@@ -241,4 +241,4 @@ export def LspInlayHintsOptionsChanged()
   endif
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -2063,4 +2063,4 @@ export def NewLspServer(serverParams: dict<any>): dict<any>
   return lspserver
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/markdown.vim
+++ b/autoload/lsp/markdown.vim
@@ -754,4 +754,4 @@ export def ParseMarkdown(data: list<string>, width: number = 80): dict<list<any>
   return document
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/offset.vim
+++ b/autoload/lsp/offset.vim
@@ -165,4 +165,4 @@ export def DecodeLocation(lspserver: dict<any>, location: dict<any>)
   endif
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -254,4 +254,4 @@ export def PopupConfigure(type: string, popupAttrs: dict<any>): dict<any>
   return popupAttrs
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/outline.vim
+++ b/autoload/lsp/outline.vim
@@ -301,4 +301,4 @@ export def OpenOutlineWindow(cmdmods: string, winsize: number)
   prevWinID->win_gotoid()
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/selection.vim
+++ b/autoload/lsp/selection.vim
@@ -104,4 +104,4 @@ export def SelectionModify(lspserver: dict<any>, expand: bool)
   lspserver.selectionRange(fname)
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/semantichighlight.vim
+++ b/autoload/lsp/semantichighlight.vim
@@ -275,4 +275,4 @@ export def BufferInit(lspserver: dict<any>, bnr: number)
   autocmd_add(acmds)
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/signature.vim
+++ b/autoload/lsp/signature.vim
@@ -184,4 +184,4 @@ export def SignatureHelp(lspserver: dict<any>, sighelp: any): void
   endif
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/snippet.vim
+++ b/autoload/lsp/snippet.vim
@@ -79,4 +79,4 @@ export def CompletionVsnip(items: list<dict<any>>)
   endfor
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -1033,4 +1033,4 @@ export def DocSymbolPopup(lspserver: dict<any>, docSymbol: any, fname: string)
   SymbolPopupMenu(symList)
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/textedit.vim
+++ b/autoload/lsp/textedit.vim
@@ -322,4 +322,4 @@ export def ApplyWorkspaceEdit(workspaceEdit: dict<any>)
   endfor
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/typehierarchy.vim
+++ b/autoload/lsp/typehierarchy.vim
@@ -171,4 +171,4 @@ export def ShowTypeHierarchy(lspserver: dict<any>, isSuper: bool, types: dict<an
   UpdateTypeHierFileInPopup(lspserver, typeUriMap)
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -363,4 +363,4 @@ export def FindNearestRootDir(startDir: string, files: list<any>): string
   return sortedList[0]
 enddef
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/ftplugin/lspgfm.vim
+++ b/ftplugin/lspgfm.vim
@@ -76,4 +76,4 @@ def RenderGitHubMarkdownText()
 enddef
 RenderGitHubMarkdownText()
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -173,4 +173,4 @@ if exists('#User#LspSetup')
   :doautocmd <nomodeline> User LspSetup
 endif
 
-# vim: shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/syntax/lspgfm.vim
+++ b/syntax/lspgfm.vim
@@ -20,4 +20,4 @@ for region in get(b:, 'lsp_syntax', [])
   endif
 endfor
 
-# vim: tabstop=8 shiftwidth=2 softtabstop=2
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/clangd_offsetencoding.vim
+++ b/test/clangd_offsetencoding.vim
@@ -475,4 +475,4 @@ def g:Test_LspTypeHier_multibyte()
   :%bw!
 enddef
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -1804,4 +1804,4 @@ def g:StartLangServer(): bool
   return g:StartLangServerWithFile('Xtest.c')
 enddef
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/common.vim
+++ b/test/common.vim
@@ -163,4 +163,4 @@ def g:StartLangServerWithFile(fname: string): bool
   return serverStatus
 enddef
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/gopls_tests.vim
+++ b/test/gopls_tests.vim
@@ -154,4 +154,4 @@ def g:StartLangServer(): bool
   return g:StartLangServerWithFile('Xtest.go')
 enddef
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/not_lspserver_related_tests.vim
+++ b/test/not_lspserver_related_tests.vim
@@ -11,4 +11,4 @@ def g:StartLangServer(): bool
   return true
 enddef
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -48,4 +48,4 @@ done
 echo "SUCCESS: All the tests passed."
 exit 0
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/runner.vim
+++ b/test/runner.vim
@@ -52,4 +52,4 @@ endtry
 
 qall!
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/rust_tests.vim
+++ b/test/rust_tests.vim
@@ -134,4 +134,4 @@ def g:StartLangServer(): bool
   return status
 enddef
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/term_util.vim
+++ b/test/term_util.vim
@@ -122,4 +122,4 @@ func StopVimInTerminal(buf, kill = 1)
   endif
 endfunc
 
-" vim: shiftwidth=2 sts=2 expandtab
+" vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/tsserver_tests.vim
+++ b/test/tsserver_tests.vim
@@ -40,4 +40,4 @@ def g:StartLangServer(): bool
   return g:StartLangServerWithFile('Xtest.ts')
 enddef
 
-# vim: shiftwidth=2 softtabstop=2 noexpandtab
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab


### PR DESCRIPTION
Add noexpandtab and tabstop=8 where missing (should really be specified as users may override Vim defaults in their vimrcs)

Note that in test/term_util.vim expandtab has been changed to noexpandtab, though there is no change to the existing indentation