### PR TITLE
Fix configs formatting, markdown lsp heading

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -790,7 +790,6 @@ call LspAddServer([#{name: 'vscode-json-server',
                  \ }])
 ```
 _Note_: The JSON language server supports code completion only if the _snippetSupport_ option is enabled.
-```
 
 <a name="vscode-markdown-lsp"/></a>
 ## VS Code Markdown Language Server


### PR DESCRIPTION
Sorry, I broke this in my previous commit, I'd originally included a code snippet showing how to set the snippetSupport option for JSON, but replaced it with a simple note when I saw the same thing had been noted for CSS language server.