### PR TITLE
Check for documentRangeFormatting capability in FormatExpr()

### DIFF
--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -43,6 +43,7 @@ var SupportedCheckFns = {
   declaration: (lspserver) => lspserver.isDeclarationProvider,
   definition: (lspserver) => lspserver.isDefinitionProvider,
   documentFormatting: (lspserver) => lspserver.isDocumentFormattingProvider,
+  documentRangeFormatting: (lspserver) => lspserver.isDocumentRangeFormattingProvider,
   documentHighlight: (lspserver) => lspserver.isDocumentHighlightProvider,
   documentSymbol: (lspserver) => lspserver.isDocumentSymbolProvider,
   foldingRange: (lspserver) => lspserver.isFoldingRangeProvider,

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -144,6 +144,18 @@ export def ProcessServerCaps(lspserver: dict<any>, caps: dict<any>)
     lspserver.isDocumentSymbolProvider = false
   endif
 
+  # documentRangeFormattingProvider
+  if lspserver.caps->has_key('documentRangeFormattingProvider')
+    if lspserver.caps.documentRangeFormattingProvider->type() == v:t_bool
+      lspserver.isDocumentRangeFormattingProvider =
+				lspserver.caps.documentRangeFormattingProvider
+    else
+      lspserver.isDocumentRangeFormattingProvider = true
+    endif
+  else
+    lspserver.isDocumentRangeFormattingProvider = false
+  endif
+
   # documentFormattingProvider
   if lspserver.caps->has_key('documentFormattingProvider')
     if lspserver.caps.documentFormattingProvider->type() == v:t_bool

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -1249,7 +1249,7 @@ enddef
 
 # Function to use with the 'formatexpr' option.
 export def FormatExpr(): number
-  var lspserver: dict<any> = buf.CurbufGetServerChecked('documentFormatting')
+  var lspserver: dict<any> = buf.CurbufGetServerChecked('documentRangeFormatting')
   if lspserver->empty()
     return 1
   endif

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1157,8 +1157,11 @@ enddef
 # Param: DocumentRangeFormattingParams
 def TextDocFormat(lspserver: dict<any>, fname: string, rangeFormat: bool,
 				start_lnum: number, end_lnum: number)
-  # Check whether LSP server supports formatting documents
-  if !lspserver.isDocumentFormattingProvider
+  # Check whether LSP server supports required formatting
+  if rangeFormat && !lspserver.isDocumentRangeFormattingProvider
+    util.ErrMsg('LSP server does not support range formatting')
+    return
+  elseif !lspserver.isDocumentFormattingProvider
     util.ErrMsg('LSP server does not support formatting documents')
     return
   endif


### PR DESCRIPTION
I want to set `formatexpr=lsp#lsp#FormatExpr()`, but only if range formatting is supported, otherwise I want to fallback to use `formatprg` (if set)

This change allows me to check if range formatting is supported on LspAttached:

```vim
    autocmd User LspAttached
      \ if !lsp#buffer#BufLspServerGet(bufnr(), 'documentRangeFormatting')->empty() |
      \   setlocal formatexpr=lsp#lsp#FormatExpr() |
      \ endif
```

This is probably the wrong way to achieve this outcome, the functions exported from `autoload/lsp/buffer.vim` probably aren't intended as a public API, but it does work. Is there a better way?