### PR TITLE
Fix diagnostics reporting in vala-lanauge-server

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -402,11 +402,10 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
   endif
 
   var fname: string = util.LspUriToFile(uri)
-  var bnr: number = fname->bufnr()
-  if bnr == -1
-    # Is this condition possible?
+  if !fname->bufexists() # exact match on fname, not file-pattern
     return
   endif
+  var bnr: number = fname->bufnr()
 
   var newDiags: list<dict<any>> = diags_arg
 


### PR DESCRIPTION
This may affect other language servers, but vala-language-server sends textDocument/publishDiagnostics messages for the parent directory of the current file, *after* sending diagnostics for the current file.

As the parent directory will be a match for the current buffer using `bufnr()` (matches a file-pattern, not an exact match on buffer name), but the diagnostics for the parent directory are empty, the diagnostics for the current file are initially shown and then immediately cleared.

Fix by using `bufexists()` for exact match on buffer name.

Fixes #717