### PR TITLE
Add some tests for <plug>(LspFormat) mappings

### DIFF
--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -76,7 +76,7 @@ command! -nargs=0 -bar LspDocumentSymbol lsp.ShowDocSymbols()
 command! -nargs=0 -bar LspFold lsp.FoldDocument()
 
 command! -nargs=0 -bar -range=% LspFormat lsp.TextDocFormat(<range>, <line1>, <line2>)
-def g:LspFormatFunc(type: string)
+def LspFormatFunc(type: string)
   if type ==# 'block'
     exe "normal! gv:LspFormat\<cr>"
   elseif type ==# 'line'
@@ -85,8 +85,8 @@ def g:LspFormatFunc(type: string)
     exe "normal! `[v`]:LspFormat\<cr>"
   endif
 enddef
-nnoremap <silent> <plug>(LspFormat)  <Cmd>set operatorfunc=LspFormatFunc<cr>g@
-vnoremap <silent> <plug>(LspFormat)  <Cmd>set operatorfunc=LspFormatFunc<cr>g@
+nnoremap <silent> <plug>(LspFormat) <scriptcmd>set operatorfunc=LspFormatFunc<cr>g@
+vnoremap <silent> <plug>(LspFormat) <scriptcmd>set operatorfunc=LspFormatFunc<cr>g@
 
 command! -nargs=0 -bar -count LspGotoDeclaration lsp.GotoDeclaration(v:false, <q-mods>, <count>)
 command! -nargs=0 -bar -count LspGotoDefinition lsp.GotoDefinition(v:false, <q-mods>, <count>)

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -177,6 +177,31 @@ def g:Test_LspFormatExpr()
   :%bw!
 enddef
 
+# Tests for formatting using plug mappings
+# Note: I could not get clangd to apply formatting only to ranges, even using
+# clangd version 21, so these tests apply to the entire file. The mappings do
+# work with ranges though, using other language servers, e.g. typescript
+def g:Test_LspFormat_PlugMappings()
+  edit! XLspFormat.c
+  sleep 200m
+  nmap gq <plug>(LspFormat)
+  setline(1, ['  int i;', '  int j;'])
+  redraw!
+  feedkeys('gqap', 'x')
+  assert_equal(['int i;', 'int j;'], getline(1, '$'))
+  nunmap gq
+
+  deletebufline('', 1, '$')
+  xmap gq <plug>(LspFormat)
+  setline(1, ['  int i;', '  int j;'])
+  redraw!
+  feedkeys('vapgq', 'x')
+  assert_equal(['int i;', 'int j;'], getline(1, '$'))
+  xunmap gq
+
+  :%bw!
+enddef
+
 # Test for formatting a file using 'formatprg'
 def g:Test_LspFormat_Fallback()
   # Enable fallback to Vim built-in formatting.


### PR DESCRIPTION
Two simple tests added for plug mappings, these tests do not test that only specific ranges of the buffer were formatted as I could not get clangd to actually perform range formatting, even though it says it is supported. This is not an issue with the mappings, `:{range}LspFormat` also applies to the entire file rather than the specified range.

The operator function has been changed to a script local function and then referenced using `<ScriptCmd>` to ensure it is available to call from within a vim9script function, otherwise the following error occurs:

```
Error: Test Test_LspFormat_PlugMappings() failed with exception Vim(eval):E117: Unknown function: LspFormatFunc at command line..script <path-to-lsp>/test/runner.vim[51]..function <SNR>1_LspRunTests[23]..Test_LspFormat_PlugMappings, line 6
```