### PR TITLE
Fix missing or misspelled help tags

### DIFF
--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -942,12 +942,24 @@ can map these commands to keys and make it easier to invoke them.
 			after the current position, then the last diagnostic
 			is selected.
 
+						*:LspDiag-nextWrap* *:LspDiagNextWrap*
+:LspDiag nextWrap	Jump to the next diagnostic message for the current
+			buffer after the current cursor position.
+			Wrap back to the first message when no more messages
+			are found.
+
 						*:LspDiag-prev* *:LspDiagPrev*
 :[count]LspDiag prev	Go to the [count] diagnostic message before the
 			current cursor position.  If [count] is omitted, then
 			1 is used.  If [count] exceeds the number of
 			diagnostics before the current position, then first
 			last diagnostic is selected.
+
+						*:LspDiag-prevWrap* *:LspDiagPrevWrap*
+:LspDiag prevWrap	Jump to the previous diagnostic message for the
+			current buffer before the current cursor position.
+			Wrap back to the last message when no previous
+			messages are found.
 
 						*:LspDiag-show* *:LspDiagShow*
 :LspDiag show		Creates a new location list with the diagnostics


### PR DESCRIPTION
* Fix misspelled helptag, LspOutoingCalls
* Add missing helptags for LspDiag shortcut commands, e.g. `:LspDiagShow`
* Add helptags for LspDiag nextWrap/prevWrap and friends