### PR TITLE
Improve symbol search when needOffsetEncoding

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1644,23 +1644,18 @@ def WorkspaceQuerySymbols(lspserver: dict<any>, query: string, firstCall: bool, 
 
   var symInfo: list<dict<any>> = reply.result
 
-  if lspserver.needOffsetEncoding
-    # Decode the position encoding in all the symbol locations
-    symInfo->map((_, sym) => {
-      if sym->has_key('location')
-	lspserver.decodeLocation(sym.location)
-      endif
-      return sym
-    })
-  endif
-
   if firstCall && symInfo->len() == 1
     # If there is only one symbol, then jump to the symbol location
     var symLoc: dict<any> = symInfo[0]->get('location', {})
     if !symLoc->empty()
+      # Decode the position encoding in the symbol location
+      if lspserver.needOffsetEncoding
+	lspserver.decodeLocation(symLoc)
+      endif
       symbol.GotoSymbol(lspserver, symLoc, false, cmdmods)
     endif
   else
+    # Note: decoding position encoding delayed until jumping to location
     symbol.WorkspaceSymbolPopup(lspserver, query, symInfo, cmdmods)
   endif
 enddef

--- a/autoload/lsp/symbol.vim
+++ b/autoload/lsp/symbol.vim
@@ -9,6 +9,7 @@ vim9script
 import './options.vim' as opt
 import './util.vim'
 import './outline.vim'
+import './offset.vim'
 
 # Initialize the highlight group and the text property type used for
 # document symbol search
@@ -90,7 +91,7 @@ def FilterSymbols(lspserver: dict<any>, popupID: number, key: string): bool
 enddef
 
 # Jump to the location of a symbol selected in the popup menu
-def JumpToWorkspaceSymbol(cmdmods: string, popupID: number, result: number): void
+def JumpToWorkspaceSymbol(lspserver: dict<any>, cmdmods: string, popupID: number, result: number): void
   # clear the message displayed at the command-line
   :echo ''
 
@@ -141,6 +142,9 @@ def JumpToWorkspaceSymbol(cmdmods: string, popupID: number, result: number): voi
     # Set the previous cursor location mark. Instead of using setpos(), m' is
     # used so that the current location is added to the jump list.
     :normal! m'
+    if lspserver.needOffsetEncoding
+      offset.DecodePosition(lspserver, bufnr(), symTbl[result - 1].pos)
+    endif
     setcursorcharpos(symTbl[result - 1].pos.line + 1,
 		     util.GetCharIdxWithoutCompChar(bufnr(),
 						    symTbl[result - 1].pos) + 1)
@@ -168,7 +172,7 @@ def ShowSymbolMenu(lspserver: dict<any>, query: string, cmdmods: string)
       fixed: 1,
       close: 'button',
       filter: function(FilterSymbols, [lspserver]),
-      callback: function('JumpToWorkspaceSymbol', [cmdmods])
+      callback: function('JumpToWorkspaceSymbol', [lspserver, cmdmods])
   })
   lspserver.workspaceSymbolPopup = popup_menu([], popupAttrs)
   lspserver.workspaceSymbolQuery = query


### PR DESCRIPTION
When the language server does not support utf-32 position encoding, workspace symbol search is painfully slow because locations for all symbols returned by the server are decoded before opening the popup, even though locations are only needed when jumping to a location.

Fix by delaying decoding the position until jumping to the location.

Fixes #721