### PR TITLE
Strip all control characters before trimming echoed diagnostic messages.

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -670,7 +670,7 @@ def ShowCurrentDiagInStatusLine()
       code = $'[{diag.code}] '
     endif
     var msgNoLineBreak = code ..
-	diag.message->substitute("\n", ' ', '')->substitute("\\n", ' ', '')
+	diag.message->substitute("[[:cntrl:]]", ' ', 'g')
     :echo msgNoLineBreak[ : max_width]
   else
     # clear the previous message


### PR DESCRIPTION
When using rust-analyzer I was seeing echoed diagnostic messages that were too long, causing wraps. It appears this was because only the first line break was being stripped. This change removes all line breaks to fix that specific issue.

I've included two other changes as well:

* Strip all control characters. They all fall into two categories: invisible (e.g. visual bell) or visually disruptive (e.g. tab, line breaks).
* Don't strip escaped line breaks because they aren't interpreted by `echo`. To see this for yourself, you can run:

```
let g:oneline = "one\\ntwo"
echo g:oneline
```

Taken together, I think this makes echoing diagnostic errors more robust to all language servers.