### PR TITLE
Catch cases where the semanticTokens reply equals null

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -461,6 +461,10 @@ def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel,
     return
   endif
 
+  if reply.result == v:null
+    reply.result = {}
+  endif
+
   RpcCb(lspserver, reply.result)
 enddef
 


### PR DESCRIPTION
Check for null replies, which are valid according to spec https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_fullRequeste

Fixes https://github.com/docker/docker-language-server/issues/498#issuecomment-3763533336