### PR TITLE
Only send the base filetype when a file has multiple filetypes

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -595,7 +595,7 @@ def TextdocDidOpen(lspserver: dict<any>, bnr: number, ftype: string): void
   var params = {
     textDocument: {
       uri: util.LspBufnrToUri(bnr),
-      languageId: ftype,
+      languageId: util.Basetype(ftype),
       # Use Vim 'changedtick' as the LSP document version number
       version: bnr->getbufvar('changedtick'),
       text: bnr->getbufline(1, '$')->join("\n") .. "\n"

--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -363,4 +363,13 @@ export def FindNearestRootDir(startDir: string, files: list<any>): string
   return sortedList[0]
 enddef
 
+# Needed for some cases where a file has multiple filetypes
+export def Basetype(ftype: string): string
+  if stridx(ftype, '.') >= 0
+    return ftype->split('\.')[0]
+  else
+    return ftype
+  endif
+enddef
+
 # vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab


### PR DESCRIPTION
In case of a dockercompose file, which is technically yaml, it would make sense to set it's filetype to `dockercompose.yaml`. This commit makes sure only the basename is sent as languageId to the server.

Fixes https://github.com/yegappan/lsp/issues/745

This strictly needs the `languageId` to be the first filetype. So `dockercompose.yaml` works, but not `yaml.dockercompose`.

@yegappan Let me know if you would like a more flexible solution! If this is okay, I would add another commit to document this.