### PR TITLE
fix: hardcoded log dir

### DIFF
--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -24,7 +24,7 @@ enddef
 # Lsp server trace log directory
 var lsp_log_dir: string
 if has('unix')
-  lsp_log_dir = '/tmp/'
+  lsp_log_dir = (exists('$TMPDIR') && !empty($TMPDIR) ? $TMPDIR : '/tmp')->fnamemodify(':p')
 else
   lsp_log_dir = $TEMP .. '\\'
 endif


### PR DESCRIPTION
### Problem

`/tmp` directory is not always present or writable e.g. on Termux `LspServer debug on` fails.

### Solution

Respect and use `$TMPDIR` when present.