### PR TITLE
Add documentationFormat setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ call LspOptionsSet(#{
         \   completionKinds: {},
         \   filterCompletionDuplicates: v:false,
         \   condensedCompletionMenu: v:false,
+        \   documentationFormat: ['markdown', 'plaintext'],
 	\ })
 ```
 

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -466,7 +466,7 @@ export def GetClientCaps(): dict<any>
       completion: {
 	dynamicRegistration: false,
 	completionItem: {
-	  documentationFormat: ['markdown', 'plaintext'],
+	  documentationFormat: opt.lspOptions.documentationFormat,
 	  resolveSupport: {
 	    properties: ['detail', 'documentation']
 	  },
@@ -512,7 +512,7 @@ export def GetClientCaps(): dict<any>
       },
       hover: {
 	dynamicRegistration: false,
-	contentFormat: ['markdown', 'plaintext']
+	contentFormat: opt.lspOptions.documentationFormat,
       },
       implementation: {
 	dynamicRegistration: false,
@@ -543,7 +543,7 @@ export def GetClientCaps(): dict<any>
       signatureHelp: {
 	dynamicRegistration: false,
 	signatureInformation: {
-	  documentationFormat: ['markdown', 'plaintext'],
+	  documentationFormat: opt.lspOptions.documentationFormat,
 	  activeParameterSupport: true
 	}
       },

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -211,6 +211,9 @@ export var lspOptions: dict<any> = {
 
   # Ignore >ItemsIsIncomplete< messages from misbehaving servers:
   ignoreCompleteItemsIsIncomplete: [],
+
+  # Text format for documentation and hovers.
+  documentationFormat: ['markdown', 'plaintext'],
 }
 
 # set the LSP plugin options from the user provided option values

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -848,6 +848,11 @@ ignoreCompleteItemsIsIncomplete |List| of strings option.
 			that are misbehaving and always send this
 			kind of 'IsIncomplete' messages.
 
+						*lsp-opt-documentationFormat*
+documentationFormat |List| of strings option.
+			DocumentationFormat to tell the LSP we want, in order
+			of preference.
+
 For example, to disable the automatic placement of signs for the LSP
 diagnostic messages, you can add the following line to your .vimrc file: >
 


### PR DESCRIPTION
For many LSPs (such as Go's gopls or Zig's zls) the plaintext looks much nicer, IMO. Right now it's hard-coded to ['markdown', 'plaintext'], so add a new documentationFormat option to control this.