### PR TITLE
Call expand on server.path

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -693,6 +693,8 @@ export def AddServer(serverList: list<dict<any>>)
     endif
     server.omnicompl = server->get('omnicompl', omnicompl_def)
 
+    server.path = expand(server.path)
+
     if !server.path->executable()
       if !opt.lspOptions.ignoreMissingServer
         util.ErrMsg($'LSP server {server.path} is not found')


### PR DESCRIPTION
So you can do something like:

	call LspAddServer([{
		name:     'intelephense',
		filetype: ['php'],
		path:     '~/intelephense/node_modules/intelephense/lib/intelephense.js',
		args:     ['--stdio']
	}])

Instead of having to type out "/home/martin".

Not a huge thing, but tilde expansion works more or less everywhere else, so I would expect it to work here too.