### PR TITLE
Add maxDiagnostics option, default 200

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ call LspOptionsSet(#{
         \   diagVirtualTextAlign: 'above',
         \   diagVirtualTextWrap: 'default',
         \   noNewlineInCompletion: v:false,
+        \   maxDiagnostics: 200,
         \   omniComplete: v:null,
         \   omniCompleteAllowBare: v:false,
         \   outlineOnRight: v:false,

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -407,7 +407,7 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
   endif
   var bnr: number = fname->bufnr()
 
-  var newDiags: list<dict<any>> = diags_arg
+  var newDiags: list<dict<any>> = diags_arg->slice(0, opt.lspOptions.maxDiagnostics)
 
   if lspserver.needOffsetEncoding
     # Decode the position encoding in all the diags

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -90,6 +90,11 @@ export var lspOptions: dict<any> = {
   # Allowed valuse: 'default' | 'truncate' | 'wrap' (default is 'default')
   diagVirtualTextWrap: 'default',
 
+  # Max number of diagnostics to process when receiving diagnostic notifications
+  # from the server, processing many hundreds of diagnostics is slow, especially
+  # when offset positions also need to be decoded
+  maxDiagnostics: 200,
+
   # Suppress adding a new line on completion selection with <CR>
   noNewlineInCompletion: false,
 

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -622,6 +622,13 @@ keepFocusInReferences	|Boolean| option.  Focus on the location list window
 			after LspShowReferences.
 			By default this is set to true.
 
+						*lsp-opt-maxDiagnostics*
+maxDiagnostics		|Number| option. Maximum nmber of diagnostics to
+			process when receiving diagnostic notifications
+			from the server. Processing hundreds of diagnostic
+			messages is slow, especially when offset positions
+			need to be decoded. By default this is set to 200.
+
 					*lsp-opt-noNewlineInCompletion*
 noNewlineInCompletion	|Boolean| option.  Suppress adding a new line on
 			completion selection with <CR>.


### PR DESCRIPTION
Processing many hundreds, or in some cases thousands, of diagnostics is very slow, painfully slow when offset positions also need to be decoded.

As this also happens synchronously, it causes Vim to freeze while the diagnostics are being processed.

This is most likely to happen when opening huge minified files, the one I opened recently resulted in well over 4,000 diagnostics being sent from the server, and Vim froze for about 40 seconds. With this change, Vim still freezes for a couple of seconds, but 2 is better than 40 :-)

Fixes #762 (mostly)

P.S. With `forceOffsetEncoding: 'utf-32'` for `typescript-language-server` and `maxDiagnostics: 200`, the freeze is sub-second and barely noticeable even when opening a horrid huge minified JS file (typically by accident).