### PR TITLE
Add LspOutlineSetup and LspOutlineUpdated User autocmds

### DIFF
--- a/autoload/lsp/outline.vim
+++ b/autoload/lsp/outline.vim
@@ -135,6 +135,10 @@ export def UpdateOutlineWindow(fname: string,
     saveCursor->setpos('.')
   endif
 
+  if exists('#User#LspOutlineUpdated')
+    :doautocmd <nomodeline> User LspOutlineUpdated
+  endif
+
   prevWinID->win_gotoid()
 
   # Highlight the current symbol
@@ -318,6 +322,10 @@ def Open(cmdmods: string, winsize: number)
 	      cmd: 'OutlineHighlightCurrentSymbol()'})
 
   autocmd_add(acmds)
+
+  if exists('#User#LspOutlineSetup')
+    :doautocmd <nomodeline> User LspOutlineSetup
+  endif
 
   prevWinID->win_gotoid()
 enddef

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1878,6 +1878,21 @@ LspDiagsUpdated			A |User| autocommand invoked when new
 				lsp#diag#GetDiagsForBuf() can be used to get
 				all the diagnostics for a buffer.
 
+						*LspOutlineSetup*
+LspOutlineSetup			A |User| autocmd fired after the outline window
+				is created with |:LspOutline|. The outline
+				window will be the active window. This is
+				mainly useful to change the window settings –
+				the window is populated later, and
+				|LspOutlineUpdated| can be used to take an
+				action after the contents is updated.
+
+						*LspOutlineUpdated*
+LspOutlineUpdated		A |User| autocmd fired after the contents of
+				the outline window is updated, including on
+				the initial populate when it's opened. The
+				outline window will be the active window.
+
 						*LspProgressUpdate*
 LspProgressUpdate		A |User| autocommand invoked when a progress
 				notification ($/progress) is received from


### PR DESCRIPTION
I would like to disable the foldcolumn on the outline window and resize to the content width. As near as I can tell this isn't so easy to do now, but with these autocmds it's pretty easy:

	autocmd User LspOutlineSetup {
		setl foldcolumn=0
	}

	autocmd User LspOutlineUpdated {
		var w = getline(1, '$')->map((_, l) => l->len())->max() + 1
		exe ':vert resize ' .. min([w, 40])
	}