### PR TITLE
Make :LspOutline {close,toggle} work in the outline window itself

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -997,7 +997,7 @@ export def Outline(ctl: string, cmdmods: string, winsize: number)
   endif
 
   var lspserver: dict<any> = buf.CurbufGetServerChecked('documentSymbol')
-  if lspserver->empty() || !lspserver.running || !lspserver.ready
+  if (lspserver->empty() || !lspserver.running || !lspserver.ready) && fname != 'LSP-Outline'
     return
   endif
 


### PR DESCRIPTION
The lspserver check failed, as the outline window itself doesn't have a server attached to it and it would return. So add a check for that.