### PR TITLE
Expand server.path with expandcmd() instead of expand() and update docs

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -698,7 +698,7 @@ export def AddServer(serverList: list<dict<any>>)
     endif
     server.omnicompl = server->get('omnicompl', omnicompl_def)
 
-    server.path = expand(server.path)
+    server.path = expandcmd(server.path)
 
     if !server.path->executable()
       if !opt.lspOptions.ignoreMissingServer

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -207,7 +207,7 @@ Shell script, Vim script and PHP file types: >
 		     {
 			name: 'clangd',
 		        filetype: ['c', 'cpp'],
-		        path: '/usr/local/bin/clangd',
+		        path: 'clangd',
 		        args: ['--background-index']
 		     },
                      {
@@ -227,7 +227,7 @@ Shell script, Vim script and PHP file types: >
 		     {
 			name: 'bashls',
 			filetype: 'sh',
-			path: '/usr/local/bin/bash-language-server',
+			path: '~/src/bash-language-server/bash-language-server',
 			args: ['start']
 		     },
 		     {
@@ -255,8 +255,9 @@ To add a language server, the following information is needed:
 	name		(Optional) name of the language server.  Can by any
 			string.  Used in LSP messages and log files.
 						*lsp-cfg-path*
-	path		complete path to the language server executable
-			(without any arguments).
+	path		path to the language server executable (without any
+			arguments). The value is expanded with |expandcmd()|
+			and looked up in $PATH. A full path can also be used.
 						*lsp-cfg-args*
 	args		a |List| of command-line arguments passed to the
 			language server.  Each space separated language server


### PR DESCRIPTION
The expand() that I added in #765 is not correct, as it takes the 'suffixes' and 'wildignore' settings in account. You can use expand(path, true) to skip that, but reading the help and Vim source, expandcmd() seems the more appropriate function.

This also updates the docs to mention expandpath(), and updates many examples to not use a full path. I left the paths that aren't in /usr/local/bin as-is.

Fixes #770
Fixes #692