### PR TITLE
Suppress press ENTER to continue on :LspDiag show

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -580,7 +580,7 @@ export def ShowAllDiags(): void
   # make the diagnostics error list the active one and open it
   var LspQfId: number = bnr->getbufvar('LspQfId', 0)
   var LspQfNr: number = getloclist(0, {id: LspQfId, nr: 0}).nr
-  exe $':{LspQfNr} lhistory'
+  execute($':{LspQfNr} lhistory', 'silent')
   :lopen
   if !opt.lspOptions.keepFocusInDiags
     save_winid->win_gotoid()


### PR DESCRIPTION
Execute :lhistory silently to avoid Press ENTER to continue prompt

Before this change the first time I ran `:LspDiag show` for a buffer I'd get a `Press ENTER or type command to continue" prompt. 

<img width="605" height="104" alt="Screenshot 2026-03-06 at 08 20 38" src="https://github.com/user-attachments/assets/af420ac1-3518-4f52-98c8-db01596bffc1" />
