### PR TITLE
Don't send "triggerKind: -1" if omniCompleteAllowBare is enabled

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -502,10 +502,14 @@ def g:LspOmniFunc(findstart: number, base: string): any
   if findstart
 
     var [triggerKind, triggerChar] = GetTriggerAttributes(lspserver)
-    if triggerKind < 0 && !opt.lspOptions.omniCompleteAllowBare
-      # previous character is not a keyword character or a trigger character,
-      # so cancel omni completion.
-      return -2
+    if triggerKind < 0
+      # previous character is not a keyword character or a trigger character, so
+      # cancel omni completion.
+      if !opt.lspOptions.omniCompleteAllowBare
+        return -2
+      endif
+      # Override triggerKind if we want to complete anyway.
+      triggerKind = 1
     endif
 
     # first send all the changes in the current buffer to the LSP server


### PR DESCRIPTION
I use completion with lsp like so:

	call LspOptionsSet({
		autoComplete:            false,  # No autocomplete.
		omniCompleteAllowBare:   true,   # Allow omnicomplete if there are no characters.
	})

omniCompleteAllowBare is useful because it allows completing things like struct fields. But if I use `<C-x><C-o>` on a Go file with gopls like so:

	cfg := Config{
		|
	}

This results in an error:

	Error: request textDocument/completion failed
	JSON RPC parse error: json: cannot unmarshal number -1 into Go struct field CompletionContext.context.triggerKind of type protocol.
	CompletionTriggerKind, error = ParseError

	This is because it sends triggerKind: -1

	SEND: {
		"id":      6,
		"jsonrpc": "2.0",
		"method":  "textDocument/completion",
		"params": {
			"context":      {"triggerCharacter": "", "triggerKind": -1},
			"position":     {"character": 2, "line": 466},
			"textDocument": {"uri": "file:///home/martin/code/Golib/pq/connector.go"}
		}
	}

	RECV: {
		"id":      6,
		"jsonrpc": "2.0",
		"error": {
			"code":    -32700,
			"message": "JSON RPC parse error: json: cannot unmarshal number -1 into Go struct field CompletionContext.context.triggerKind of type protocol.CompletionTriggerKind"
		}
	}

It seems like a reasonable error for gopls to return, as [CompletionTriggerKind] can only be 1, 2, or 3.

So this needs to be overriden if omniCompleteAllowBare is set. After this, it sends:

	SEND: {
		"id":      8,
		"jsonrpc": "2.0",
		"method":  "textDocument/completion",
		"params": {
			"context":      {"triggerCharacter": "", "triggerKind": 1},
			"position":     {"character": 2, "line": 466},
			"textDocument": {"uri": "file:///home/martin/code/Golib/pq/connector.go"}
		}
	}

	RECV:{
		"id":      8,
		"jsonrpc": "2.0",
		"result": {
			"isIncomplete": true,
			"items": [
				[.. trim ..]
			]
		}
	}

[CompletionTriggerKind]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionTriggerKind