### PR TITLE
Do not restore cursor after applying edits

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1277,9 +1277,7 @@ def TextDocFormat(lspserver: dict<any>, fname: string, rangeFormat: bool,
 
   # interface TextEdit
   # Apply each of the text edit operations
-  var save_cursor: list<number> = getcurpos()
   textedit.ApplyTextEdits(bnr, reply.result)
-  save_cursor->setpos('.')
 enddef
 
 def DecodeCallHierarchyItem(lspserver: dict<any>, item: dict<any>)


### PR DESCRIPTION
`ApplyTextEdits` [handles changes such that the cursor need not be restored explicitly](https://github.com/cskr/lsp/blob/main/autoload/lsp/textedit.vim#L178-L202). When `:LspFormat` tries to restore the cursor's position, it places it on the incorrect line. This is particularly jarring when `LspFormat` is configured to run automatically on `BufWritePre`, as it disrupts the editing flow.

### Steps to reproduce bug on main

1. Add `ruff server` as an LSP server for Python.
2. Open a Python file with the following contents and place the cursor on the last line.
```
def main():
    pass
def foo():
    pass
def bar():
    pass
```
3. Run `:LspFormat` 
4.  Observe that the cursor jumps from `bar()` to `foo()` when two blank lines are added after each function.