### PR TITLE
Add g:lsp_options to conveniently set opts from vimrc

### DIFF
--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -2013,6 +2013,22 @@ diagnostic messages, you can add the following line to your .vimrc file: >
 
 	call g:LspOptionsSet({'autoHighlightDiags': false})
 <
+                                                 *g:lsp_options*
+For convenience the options above can also be set using this global variable
+in your vimrc. The value must be a dictionary, and supports the same options
+as calling LspOptionsSet() directly. LspOptionsSet() is automatically called
+on plugin load when g:lsp_options is set. For example, in your vimrc, this: >
+
+    vim9script
+    g:lsp_options = {autoHighlightDiags: true}
+<
+Is equivalent to this: >
+
+    vim9script
+    var lspOpts = {autoHighlightDiags: true}
+    autocmd User LspSetup g:LspOptionsSet(lspOpts)
+<
+
 				    *LspOptionsGet()* *g:LspOptionsGet()*
 The g:LspOptionsGet() function returns a |Dict| of all the LSP plugin options,
 To get a particular option value you can use the following: >

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -170,6 +170,11 @@ if has('gui_running')
   endif
 endif
 
+# Convenience option to avoid needing to add autocmd to vimrc
+if exists('g:lsp_options') && g:lsp_options->type() == v:t_dict
+  g:LspOptionsSet(g:lsp_options)
+endif
+
 # Invoke autocmd to register LSP servers and to set LSP options
 if exists('#User#LspSetup')
   :doautocmd <nomodeline> User LspSetup


### PR DESCRIPTION
## 📌 Summary

Adds `g:lsp_options` variable to allow convenient setting of plugin options without needing an autocmd in a user's vimrc

## 🧪 What This PR Improves

It seems unusual to require an autocmd to set configuration options for a plugin, so this adds a convenience global variable to allow options to be set in a vimrc without having to add an autocmd.

In my case this allows me to neatly split out plugin config in vimrc from plugin customisation in after/plugin, but in future there may be an equivalent of vim-lsp-settings for this plugin, and a user might not even need to configure servers directly, and therefore not need to set any autocmds themselves, just config options and maybe custom mappings.

## 🛠️ Changes Made

Check if `g:lsp_options` exists when loading plugin, if true automatically create `LspSetup` autocmd to call `LspOptionsSet()` with `g:lsp_options` as argument.

## 🧪 Testing

Tested locally removing my `LspSetup` autocmd to call `LspOptionsSet()` and replaced with `g:lsp_options` in vimrc. Tested with both vim9script and legacy script.  

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [X] No  

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [X] No  

## ✔️ Checklist

- [X] I have tested this with a minimal Vim9script configuration.
- [X] I have run the plugin against the relevant LSP server(s).
- [X] I have updated documentation if needed.
- [X] I have followed the project’s coding style and conventions.
- [ ] I have added tests or examples where appropriate.

