### PR TITLE
Improve code action popup layout and make it configurable

### DIFF
--- a/autoload/lsp/codeaction.vim
+++ b/autoload/lsp/codeaction.vim
@@ -87,22 +87,97 @@ def SortCodeActions(actions: list<dict<any>>): list<dict<any>>
   return ranked->map((_, item) => item.action)
 enddef
 
-def ActionMenuText(act: dict<any>): string
-  var prefix: string = ''
+def ActionMenuText(actions: list<dict<any>>): list<string>
+  var duplicateTitles = GetDuplicateActionTitles(actions)
+  var actionListLength = actions->len()
 
-  if act->get('isPreferred', false)
-    prefix = '*'
-  endif
-  var kind: string = act->get('kind', '')
-  if kind != ''
-    prefix ..= $'[{kind}] '
-  endif
+  var bitfield = opt.lspOptions.codeActionPopupDetailsBitfield
+  var hasKind: bool = and(bitfield, opt.CODEACTIONDETAILS_KIND) != 0
+  var hasFullKind: bool = and(bitfield, opt.CODEACTIONDETAILS_FULLKIND) != 0
+  var hasServer: bool = and(bitfield, opt.CODEACTIONDETAILS_SERVER) != 0
 
-  var title = act.title->substitute('\r\n', '\\r\\n', 'g')
-  title = title->substitute('\n', '\\n', 'g')
+  var strings: list<dict<string>> = []
+  var widths: list<dict<number>> = []
+  var longest = { title: 0, kind: 0, server: 0}
 
-  # Normalize newlines so each action remains a single menu row.
-  return $'{prefix}{title}'
+  for act in actions
+    var hasDuplicateTitle: bool = duplicateTitles->has_key(act->get('title', ''))
+    var width: dict<number> = {}
+    var string: dict<string> = {}
+
+    string.title = act.title->substitute('\r\n\|\n', '\\n', 'g')
+    if act->get('isPreferred', false)
+      string.title = '*' .. string.title
+    endif
+
+    string.kind = ''
+    if hasKind
+      string.kind = substitute(act->get('kind', ''), '\..*$', '', '')
+    elseif hasFullKind
+      string.kind = act->get('kind', '')
+    endif
+
+    if !empty(string.kind)
+      string.kind = printf("[%s]", string.kind)
+    endif
+
+    string.server = ''
+    if hasServer || hasDuplicateTitle
+      string.server = printf("[%s]", act->get('__lsp_server_name', ''))
+    endif
+
+    strings->add(string)
+
+    # Compute widths
+    width.title = strdisplaywidth(string.title)
+    width.kind = strdisplaywidth(string.kind)
+    width.server = strdisplaywidth(string.server)
+    width.postfix = width.server + width.kind
+    widths->add(width)
+
+    # Compute maxima
+    longest.title = max([longest.title, width.title])
+    longest.kind = max([longest.kind, width.kind])
+    longest.server = max([longest.server, width.server])
+  endfor
+
+  var popupText: list<string> = []
+
+  var minPadding = 4
+  var numWidth = actionListLength->string()->len()
+  var longestPostfix = longest.kind + longest.server
+  var popupWidth = longest.title + longestPostfix + minPadding
+
+  for i in actionListLength->range()
+    var act = actions[i]
+    var hasDuplicateTitle: bool = duplicateTitles->has_key(act->get('title', ''))
+
+    var numPrefix = printf(' %*d. ', numWidth, i + 1)
+    var line: string
+
+    if !hasKind && !hasFullKind && !hasServer && !hasDuplicateTitle
+      line = numPrefix .. strings[i].title .. ' '
+    else
+      var postfix = ''
+      if !empty(strings[i].kind)
+	postfix ..= strings[i].kind
+      endif
+
+      if !empty(strings[i].server)
+	if !empty(postfix)
+	  postfix ..= ' '
+	endif
+	postfix ..= strings[i].server
+      endif
+
+      var padding = max([minPadding, popupWidth - widths[i].title - widths[i].postfix -
+	(longest.server - widths[i].server)])
+      line = numPrefix .. strings[i].title .. repeat(' ', padding) .. postfix .. ' '
+    endif
+    popupText->add(line)
+  endfor
+
+  return popupText
 enddef
 
 def GetDuplicateActionTitles(actions: list<dict<any>>): dict<bool>
@@ -145,18 +220,6 @@ def ResolveActionServer(defaultServer: dict<any>, action: dict<any>): dict<any>
   return lspserver
 enddef
 
-def ActionMenuTextWithServerLabel(act: dict<any>, duplicateTitles: dict<bool>): string
-  var text = ActionMenuText(act)
-
-  # Only duplicate titles get source labels, keeping unique entries concise.
-  if duplicateTitles->has_key(act->get('title', ''))
-      && act->has_key('__lsp_server_name')
-    return $'{text} [{act.__lsp_server_name}]'
-  endif
-
-  return text
-enddef
-
 # Process the list of code actions returned by the LSP server, ask the user to
 # choose one action from the list and then apply it.
 # If "query" is a number, then apply the corresponding action in the list.
@@ -182,16 +245,7 @@ export def ApplyCodeAction(lspserver: dict<any>, actionlist: list<dict<any>>, qu
     return
   endif
 
-  # Compute once for the current menu render.
-  var duplicateTitles = GetDuplicateActionTitles(actions)
-
-  var text: list<string> = []
-  var act: dict<any>
-  for i in actions->len()->range()
-    act = actions[i]
-    var t = ActionMenuTextWithServerLabel(act, duplicateTitles)
-    text->add(printf(" %d. %s ", i + 1, t))
-  endfor
+  var text = ActionMenuText(actions)
 
   var choice: number
 

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -4,6 +4,10 @@ export const COMPLETIONMATCHER_CASE = 1
 export const COMPLETIONMATCHER_ICASE = 2
 export const COMPLETIONMATCHER_FUZZY = 3
 
+export const CODEACTIONDETAILS_SERVER   = 0x1
+export const CODEACTIONDETAILS_KIND     = 0x2
+export const CODEACTIONDETAILS_FULLKIND = 0x4
+
 # LSP plugin options
 # User can override these by calling the OptionsSet() function.
 export var lspOptions: dict<any> = {
@@ -24,6 +28,10 @@ export var lspOptions: dict<any> = {
 
   # Automatically populate the location list with new diagnostics
   autoPopulateDiags: false,
+
+  # Default code action details are 'kind-and-server'
+  codeActionPopupDetails: 'kind-and-server',
+  codeActionPopupDetailsBitfield: 3,
 
   # icase | fuzzy | case match for language servers that replies with a full
   # list of completion items
@@ -255,6 +263,24 @@ export def OptionsSet(opts: dict<any>)
     lspOptions.completionMatcherValue = COMPLETIONMATCHER_FUZZY
   else
     lspOptions.completionMatcherValue = COMPLETIONMATCHER_CASE
+  endif
+
+  # For faster comparison, convert the 'codeActionPopupDetails' option value from a
+  # string to a number.
+  if lspOptions.codeActionPopupDetails == 'short'
+    lspOptions.codeActionPopupDetailsBitfield = 0
+  elseif lspOptions.codeActionPopupDetails == 'server'
+    lspOptions.codeActionPopupDetailsBitfield = CODEACTIONDETAILS_SERVER
+  elseif lspOptions.codeActionPopupDetails == 'kind'
+    lspOptions.codeActionPopupDetailsBitfield = CODEACTIONDETAILS_KIND
+  elseif lspOptions.codeActionPopupDetails == 'kind-and-server'
+    lspOptions.codeActionPopupDetailsBitfield = or(CODEACTIONDETAILS_KIND, CODEACTIONDETAILS_SERVER)
+  elseif lspOptions.codeActionPopupDetails == 'full-kind'
+    lspOptions.codeActionPopupDetailsBitfield = CODEACTIONDETAILS_FULLKIND
+  elseif lspOptions.codeActionPopupDetails == 'full-kind-and-server'
+    lspOptions.codeActionPopupDetailsBitfield = or(CODEACTIONDETAILS_FULLKIND, CODEACTIONDETAILS_SERVER)
+  else
+    lspOptions.codeActionPopupDetailsBitfield = or(CODEACTIONDETAILS_KIND, CODEACTIONDETAILS_SERVER)
   endif
 
   # Apply the changed options

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1546,6 +1546,16 @@ autoPopulateDiags	|Boolean| option. Automatically populate the location
 			is added to each location list items attribute
 			'user_data'.
 
+						*lsp-opt-codeActionPopupDetails*
+codeActionPopupDetails	|String| option. Configure the details of the code popup.
+			This option accepts one of the following values:
+			    full                 - Title, full kind and server are displayed
+			    full-kind-and-server - Action title and full kind are displayed
+			    kind                 - Action title and kind are displayed
+			    kind-and-server      - Action title, kind and server are displayed (default)
+			    server               - Action title and server are displayed
+			    short                - Only the action is displayed
+
 						*lsp-opt-completionMatcher*
 completionMatcher	|String| option.  Enable fuzzy or case insensitive
 			completion for language servers that replies with a

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -926,25 +926,88 @@ def g:Test_CodeActionMenuMetadata()
     {
       title: 'Apply fallback fix',
       kind: 'quickfix',
+      __lsp_server_name: 'ExampleServer',
     },
     {
       title: 'Apply preferred fix',
       kind: 'source.fixAll',
       isPreferred: true,
+      __lsp_server_name: 'ExampleServer',
     }
   ]
 
+  g:LspOptionsSet({codeActionPopupDetails: 'short'})
   codeaction.ApplyCodeAction(lspserver, actions, '')
 
   var popups = popup_list()
   assert_equal(1, popups->len())
   var bnr = winbufnr(popups[0])
   assert_equal([
-    ' 1. *[source.fixAll] Apply preferred fix ',
-    ' 2. [quickfix] Apply fallback fix '
+    ' 1. *Apply preferred fix ',
+    ' 2. Apply fallback fix '
   ], getbufline(bnr, 1, '$'))
-
   popup_close(popups[0])
+
+  g:LspOptionsSet({codeActionPopupDetails: 'kind'})
+  codeaction.ApplyCodeAction(lspserver, actions, '')
+
+  popups = popup_list()
+  assert_equal(1, popups->len())
+  bnr = winbufnr(popups[0])
+  assert_equal([
+    ' 1. *Apply preferred fix      [source] ',
+    ' 2. Apply fallback fix      [quickfix] '
+  ], getbufline(bnr, 1, '$'))
+  popup_close(popups[0])
+
+  g:LspOptionsSet({codeActionPopupDetails: 'full-kind'})
+  codeaction.ApplyCodeAction(lspserver, actions, '')
+
+  popups = popup_list()
+  assert_equal(1, popups->len())
+  bnr = winbufnr(popups[0])
+  assert_equal([
+    ' 1. *Apply preferred fix    [source.fixAll] ',
+    ' 2. Apply fallback fix           [quickfix] '
+  ], getbufline(bnr, 1, '$'))
+  popup_close(popups[0])
+
+  g:LspOptionsSet({codeActionPopupDetails: 'server'})
+  codeaction.ApplyCodeAction(lspserver, actions, '')
+
+  popups = popup_list()
+  assert_equal(1, popups->len())
+  bnr = winbufnr(popups[0])
+  assert_equal([
+    ' 1. *Apply preferred fix    [ExampleServer] ',
+    ' 2. Apply fallback fix      [ExampleServer] '
+  ], getbufline(bnr, 1, '$'))
+  popup_close(popups[0])
+
+  g:LspOptionsSet({codeActionPopupDetails: 'kind-and-server'})
+  codeaction.ApplyCodeAction(lspserver, actions, '')
+
+  popups = popup_list()
+  assert_equal(1, popups->len())
+  bnr = winbufnr(popups[0])
+  assert_equal([
+    ' 1. *Apply preferred fix      [source] [ExampleServer] ',
+    ' 2. Apply fallback fix      [quickfix] [ExampleServer] '
+  ], getbufline(bnr, 1, '$'))
+  popup_close(popups[0])
+
+  g:LspOptionsSet({codeActionPopupDetails: 'full-kind-and-server'})
+  codeaction.ApplyCodeAction(lspserver, actions, '')
+
+  popups = popup_list()
+  assert_equal(1, popups->len())
+  bnr = winbufnr(popups[0])
+  assert_equal([
+    ' 1. *Apply preferred fix    [source.fixAll] [ExampleServer] ',
+    ' 2. Apply fallback fix           [quickfix] [ExampleServer] '
+  ], getbufline(bnr, 1, '$'))
+  popup_close(popups[0])
+
   g:LspOptionsSet({usePopupInCodeAction: false})
 enddef
 

--- a/test/stub_lspserver_tests.vim
+++ b/test/stub_lspserver_tests.vim
@@ -483,12 +483,14 @@ def g:Test_CodeActionMenu_ServerLabelOnlyForDuplicateTitles()
 
   codeaction.ApplyCodeAction({}, actions, '')
 
+  g:LspOptionsSet({codeActionPopupDetails: 'short'})
+
   var popups = popup_list()
   assert_equal(1, popups->len())
   var bnr = winbufnr(popups[0])
   assert_equal([
-    ' 1. Duplicate action [srvA] ',
-    ' 2. Duplicate action [srvB] ',
+    ' 1. Duplicate action    [srvA] ',
+    ' 2. Duplicate action    [srvB] ',
     ' 3. Unique action '
   ], getbufline(bnr, 1, '$'))
 


### PR DESCRIPTION
## 📌 Summary

Code action popups now look as follows by default

```
1. Convert default export to named export       [refactor] [typescript-ls]
2. Convert named export to default export       [refactor] [typescript-ls]
3. Add 'Traktor' to global dictionary           [quickfix] [codebook]
4. Add current file to ignore list              [quickfix] [codebook]
```

The following options are now provided to configure this behavior via

``` vim
codeActionPopupStyle: 'default',
```

```
'default'    : Action title, kind and server are displayed
'full'       : Title, full kind and server are displayed
'full-kind'  : Action title and full kind are displayed
'kind'       : Action title and kind are displayed
'server'     : Action title and server are displayed
'short'      : Only the action is displayed
```

Provide a clear and concise description of the changes in this PR.

---

## 🔍 Related Issues

Link any related issues or discussions:

- Related to https://github.com/yegappan/lsp/issues/660
---

## 🧪 What This PR Improves

Improves the rendered details of the the code action popup

---

## 🛠️ Changes Made

List the key changes:

- Uses a new layout
- Makes the layout confugurable

---

## 🧪 Testing

Describe how you tested the changes. Include steps, commands, or sample files.

# Steps to verify behavior
# If applicable, include screenshots or logs.

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

If yes, explain:

---

## 📚 Documentation

Does this PR require documentation updates?

- [x] Yes  
- [ ] No  

If yes, describe what needs updating.

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [x] I have updated documentation if needed.
- [x] I have followed the project’s coding style and conventions.
- [x] I have added tests or examples where appropriate.

