### PR TITLE
Enable lsp on VimEnter, not plugin load, with option not to enable on startup

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -543,6 +543,30 @@ def AddBufLocalAutocmds(lspserver: dict<any>, bnr: number): void
   autocmd_add(acmds)
 enddef
 
+def RemoveBufLocalAutocmds(bnr: number): void
+  silent! autocmd_delete([{bufnr: bnr, group: 'LSPBufferAutocmds'}])
+enddef
+
+def AddBufListener(lspserver: dict<any>, bnr: number): void
+  # Add a per-buffer listener so incremental text changes are pushed to the
+  # server and pull diagnostics are debounced from edits.
+  var listenerId = listener_add((_bnr: number, start: number, end: number, added: number, changes: list<dict<number>>) => {
+    lspserver.textdocDidChange(bnr)
+    if lspserver.isDiagnosticsProvider
+      lspserver.queuePullDiagnostics(bnr)
+    endif
+  }, bnr)
+  var listenerIds = bnr->getbufvar('LspListenerIds', [])
+  setbufvar(bnr, 'LspListenerIds', listenerIds + [listenerId])
+enddef
+
+def RemoveBufListener(bnr: number): void
+  for listenerId in bnr->getbufvar('LspListenerIds', [])
+    listener_remove(listenerId)
+  endfor
+  setbufvar(bnr, 'LspListenerIds', [])
+enddef
+
 # The LSP server with ID "lspserverId" is ready, initialize the LSP features
 # for buffer "bnr".
 def BufferInit(lspserverId: number, bnr: number): void
@@ -554,14 +578,7 @@ def BufferInit(lspserverId: number, bnr: number): void
   var ftype: string = bnr->getbufvar('&filetype')
   lspserver.textdocDidOpen(bnr, ftype)
 
-  # Add a per-buffer listener so incremental text changes are pushed to the
-  # server and pull diagnostics are debounced from edits.
-  listener_add((_bnr: number, start: number, end: number, added: number, changes: list<dict<number>>) => {
-    lspserver.textdocDidChange(bnr)
-    if lspserver.isDiagnosticsProvider
-      lspserver.queuePullDiagnostics(bnr)
-    endif
-  }, bnr)
+  AddBufListener(lspserver, bnr)
 
   AddBufLocalAutocmds(lspserver, bnr)
 
@@ -678,11 +695,19 @@ enddef
 # Notify LSP server to remove a file
 export def RemoveFile(bnr: number): void
   var lspservers: list<dict<any>> = buf.BufLspServersGet(bnr)
+  if !lspservers->empty()
+    RemoveBufLocalAutocmds(bnr)
+    RemoveBufListener(bnr)
+  endif
   # Iterate over a copy because BufLspServerRemove mutates the underlying list.
   for lspserver in lspservers->copy()
     if lspserver->empty()
       continue
     endif
+    silent! autocmd_delete([{group: 'LSPBufferAutocmds',
+                   event: 'User',
+                   pattern: $'LspServerReady_{lspserver.id}',
+                   cmd: $'BufferInit({lspserver.id}, {bnr})'}])
     if lspserver.running
       lspserver.textdocDidClose(bnr)
     endif

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -28,6 +28,8 @@ import './semantichighlight.vim'
 var ftypeServerMap: dict<list<dict<any>>> = {}
 
 var lspInitializedOnce = false
+var lspUserSetupOnce = false
+var lspEnabled = false
 
 def LspInitOnce()
   # Define all plugin highlights/proptypes once per Vim session.
@@ -53,6 +55,61 @@ def LspInitOnce()
   semantichighlight.InitOnce()
 
   lspInitializedOnce = true
+enddef
+
+def RegisterEvents()
+  augroup LspAutoCmds
+    autocmd!
+    autocmd BufNewFile,BufReadPost,FileType * AddFile(expand('<abuf>')->str2nr())
+    # Note that when BufWipeOut is invoked, the current buffer may be different
+    # from the buffer getting wiped out.
+    autocmd BufWipeOut * RemoveFile(expand('<abuf>')->str2nr())
+    autocmd BufWinEnter * BufferLoadedInWin(expand('<abuf>')->str2nr())
+    # Pull fresh diagnostics when a file is modified outside Vim and reloaded
+    autocmd FileChangedShellPost * BufferExternallyChanged(expand('<abuf>')->str2nr())
+  augroup END
+enddef
+
+def DeregisterEvents()
+  augroup LspAutoCmds
+    autocmd!
+  augroup END
+enddef
+
+export def LspEnable()
+  if lspEnabled
+    return
+  endif
+
+  if !lspUserSetupOnce
+    # Invoke LspSetup user autocmd once
+    if exists('#User#LspSetup')
+      :doautocmd <nomodeline> User LspSetup
+    endif
+    lspUserSetupOnce = true
+  endif
+
+  RegisterEvents()
+
+  for binfo in getbufinfo()
+    AddFile(binfo.bufnr)
+  endfor
+
+  lspEnabled = true
+enddef
+
+export def LspDisable()
+  if !lspEnabled
+    return
+  endif
+
+  DeregisterEvents()
+
+  for binfo in getbufinfo()
+    RemoveFile(binfo.bufnr)
+  endfor
+
+  lspEnabled = false
 enddef
 
 # Returns the LSP servers for the a specific filetype. Based on how well there
@@ -556,7 +613,7 @@ def BufferInit(lspserverId: number, bnr: number): void
         doautocmd <nomodeline> User LspAttached
       else
         # Delay doautocmd until entering the buffer
-        execute 'autocmd LSPAutoCmds BufEnter <buffer=' .. bnr .. '>'
+        execute 'autocmd LspAutoCmds BufEnter <buffer=' .. bnr .. '>'
               \ .. ' ++once doautocmd <nomodeline> User LspAttached'
       endif
     endif

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -2056,7 +2056,9 @@ The plugin can be enabled after startup using the |g:LspEnable()| function.
 The g:LspEnable() function enables the LSP plugin after Vim startup.
 
 				    *LspDisable()* *g:LspDisable()*
-The g:LspDisable() function disables the LSP plugin after Vim startup.
+The g:LspDisable() function disables LSP features for buffers after Vim
+startup. It does not stop language servers that are already running. To
+stop running servers, use |:LspServer| stop.
 
 				    *LspOptionsGet()* *g:LspOptionsGet()*
 The g:LspOptionsGet() function returns a |Dict| of all the LSP plugin options,

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -2028,7 +2028,7 @@ diagnostic messages, you can add the following line to your .vimrc file: >
 
 	call g:LspOptionsSet({'autoHighlightDiags': false})
 <
-                                                 *g:lsp_options*
+						*g:lsp_options*
 For convenience the options above can also be set using this global variable
 in your vimrc. The value must be a dictionary, and supports the same options
 as calling LspOptionsSet() directly. LspOptionsSet() is automatically called
@@ -2043,6 +2043,20 @@ Is equivalent to this: >
     var lspOpts = {autoHighlightDiags: true}
     autocmd User LspSetup g:LspOptionsSet(lspOpts)
 <
+						*g:lsp_enable*
+The plugin is automatically enabled on Vim startup by default. You can use
+this option to disable auto enabling LSP during Vim startup, e.g. >
+
+    vim9script
+    g:lsp_enable = false
+<
+The plugin can be enabled after startup using the |g:LspEnable()| function.
+
+				    *LspEnable()* *g:LspEnable()*
+The g:LspEnable() function enables the LSP plugin after Vim startup.
+
+				    *LspDisable()* *g:LspDisable()*
+The g:LspDisable() function disables the LSP plugin after Vim startup.
 
 				    *LspOptionsGet()* *g:LspOptionsGet()*
 The g:LspOptionsGet() function returns a |Dict| of all the LSP plugin options,

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -46,19 +46,6 @@ def g:LspServerRunning(ftype: string): bool
   return lsp.ServerRunning(ftype)
 enddef
 
-augroup LSPAutoCmds
-  au!
-  autocmd BufNewFile,BufReadPost,FileType * lsp.AddFile(expand('<abuf>')->str2nr())
-  # Note that when BufWipeOut is invoked, the current buffer may be different
-  # from the buffer getting wiped out.
-  autocmd BufWipeOut * lsp.RemoveFile(expand('<abuf>')->str2nr())
-  autocmd BufWinEnter * lsp.BufferLoadedInWin(expand('<abuf>')->str2nr())
-  # Pull fresh diagnostics when a file is modified outside Vim and reloaded
-  autocmd FileChangedShellPost * lsp.BufferExternallyChanged(expand('<abuf>')->str2nr())
-augroup END
-
-autocmd VimLeavePre * silent! lsp.FastShutdownExitAllServers()
-
 # LSP commands
 command! -nargs=? -bar -range LspCodeAction lsp.CodeAction(<line1>, <line2>, <q-args>)
 command! -nargs=? -bar LspFixAll lsp.SourceCodeAction('source.fixAll', <q-args>)
@@ -175,9 +162,28 @@ if exists('g:lsp_options') && g:lsp_options->type() == v:t_dict
   g:LspOptionsSet(g:lsp_options)
 endif
 
-# Invoke autocmd to register LSP servers and to set LSP options
-if exists('#User#LspSetup')
-  :doautocmd <nomodeline> User LspSetup
-endif
+def LspEnable()
+  augroup LSPAutoCmds
+    au!
+    autocmd BufNewFile,BufReadPost,FileType * lsp.AddFile(expand('<abuf>')->str2nr())
+    # Note that when BufWipeOut is invoked, the current buffer may be different
+    # from the buffer getting wiped out.
+    autocmd BufWipeOut * lsp.RemoveFile(expand('<abuf>')->str2nr())
+    autocmd BufWinEnter * lsp.BufferLoadedInWin(expand('<abuf>')->str2nr())
+    # Pull fresh diagnostics when a file is modified outside Vim and reloaded
+    autocmd FileChangedShellPost * lsp.BufferExternallyChanged(expand('<abuf>')->str2nr())
 
+    autocmd VimLeavePre * silent! lsp.FastShutdownExitAllServers()
+  augroup END
+
+  # Invoke autocmd to register LSP servers and to set LSP options
+  if exists('#User#LspSetup')
+    :doautocmd <nomodeline> User LspSetup
+  endif
+enddef
+
+augroup LspEnable
+  au!
+  autocmd VimEnter * LspEnable()
+augroup END
 # vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -176,9 +176,14 @@ if exists('g:lsp_options') && g:lsp_options->type() == v:t_dict
 endif
 
 if get(g:, 'lsp_enable', true)
-  augroup LspEnable
-    au!
-    autocmd VimEnter * lsp.LspEnable()
-  augroup END
+  if v:vim_did_enter
+    # allow for plugin load, e.g. packadd lsp, after VimEnter
+    lsp.LspEnable()
+  else
+    augroup LspEnable
+      au!
+      autocmd VimEnter * lsp.LspEnable()
+    augroup END
+  endif
 endif
 # vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -46,6 +46,19 @@ def g:LspServerRunning(ftype: string): bool
   return lsp.ServerRunning(ftype)
 enddef
 
+def g:LspEnable()
+  lsp.LspEnable()
+enddef
+
+def g:LspDisable()
+  lsp.LspDisable()
+enddef
+
+augroup LspExit
+  au!
+  autocmd VimLeavePre * silent! lsp.FastShutdownExitAllServers()
+augroup END
+
 # LSP commands
 command! -nargs=? -bar -range LspCodeAction lsp.CodeAction(<line1>, <line2>, <q-args>)
 command! -nargs=? -bar LspFixAll lsp.SourceCodeAction('source.fixAll', <q-args>)
@@ -162,28 +175,10 @@ if exists('g:lsp_options') && g:lsp_options->type() == v:t_dict
   g:LspOptionsSet(g:lsp_options)
 endif
 
-def LspEnable()
-  augroup LSPAutoCmds
+if get(g:, 'lsp_enable', true)
+  augroup LspEnable
     au!
-    autocmd BufNewFile,BufReadPost,FileType * lsp.AddFile(expand('<abuf>')->str2nr())
-    # Note that when BufWipeOut is invoked, the current buffer may be different
-    # from the buffer getting wiped out.
-    autocmd BufWipeOut * lsp.RemoveFile(expand('<abuf>')->str2nr())
-    autocmd BufWinEnter * lsp.BufferLoadedInWin(expand('<abuf>')->str2nr())
-    # Pull fresh diagnostics when a file is modified outside Vim and reloaded
-    autocmd FileChangedShellPost * lsp.BufferExternallyChanged(expand('<abuf>')->str2nr())
-
-    autocmd VimLeavePre * silent! lsp.FastShutdownExitAllServers()
+    autocmd VimEnter * lsp.LspEnable()
   augroup END
-
-  # Invoke autocmd to register LSP servers and to set LSP options
-  if exists('#User#LspSetup')
-    :doautocmd <nomodeline> User LspSetup
-  endif
-enddef
-
-augroup LspEnable
-  au!
-  autocmd VimEnter * LspEnable()
-augroup END
+endif
 # vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -68,6 +68,7 @@ def g:Test_LspFormat()
     int j;
   END
   setline(1, lines)
+  g:WaitForServerFileLoad(0)
   :redraw!
   :LspFormat
   var expected: list<string> =<< trim DATA

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -59,6 +59,29 @@ var lspServers = [{
 call LspAddServer(lspServers)
 
 
+# Test for disabling and then re-enabling LSP
+def g:Test_LspEnableDisable()
+  :silent! edit XLspEnableDisable.c
+  :sleep 200m
+  var lines: list<string> =<< trim END
+    int i:
+    int j;
+  END
+  setline(1, lines)
+  var bnr = bufnr()
+  g:WaitForServerFileLoad(1)
+
+  g:WaitForAssert(() => assert_false(empty(lsp#diag#GetDiagsForBuf())))
+
+  g:LspDisable()
+  g:WaitForAssert(() => assert_true(empty(lsp#diag#GetDiagsForBuf())))
+
+  g:LspEnable()
+  g:WaitForAssert(() => assert_false(empty(lsp#diag#GetDiagsForBuf())))
+
+  :%bw!
+enddef
+
 # Test for formatting a file using LspFormat
 def g:Test_LspFormat()
   :silent! edit XLspFormat.c

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -68,7 +68,6 @@ def g:Test_LspEnableDisable()
     int j;
   END
   setline(1, lines)
-  var bnr = bufnr()
   g:WaitForServerFileLoad(1)
 
   g:WaitForAssert(() => assert_false(empty(lsp#diag#GetDiagsForBuf())))

--- a/test/common.vim
+++ b/test/common.vim
@@ -22,6 +22,9 @@ def g:LoadLspPlugin()
 
   g:LSPTest = true
   source ../plugin/lsp.vim
+
+  # Call g:LspEnable() because VimEnter only triggered after test runner sourced
+  g:LspEnable()
 enddef
 
 # The WaitFor*() functions are reused from the Vim test suite.


### PR DESCRIPTION
## 📌 Summary

Only trigger LSP setup on VimEnter, add an option not to enable on initial Vim startup, and add functions to allow LSP to be enabled/disabled as desired. 

---

## 🔍 Related Issues

Link any related issues or discussions:

- Related to #801

---

## 🧪 What This PR Improves

Enabling LSP only on VimEnter rather than plugin load allows server configuration outside of vimrc in after/plugin 

Adding an option not to enable on Vim startup allows deferring LSP startup until needed. LSP is often not needed for a quick edit, some users might not want it enabled automatically for every Vim session.

---

## 🛠️ Changes Made

List the key changes:

- Wrap  LSP autocmds and triggering of LspSetup User autocmd into an `LspEnable()` autoload function that is called on VimEnter by default
- Add `g:lsp_enable` option, default true. When false, `LspEnable()` is not called on VimEnter
- Add `g:LspEnable()` and `g:LspDisable()` functions to allow users to enable/disable LSP as needed

---

## 🧪 Testing

Tested locally on MacOS using Vim 9.2.0421 with plugin options specified via `g:lsp_options` in `vimrc` and server configuration in `~/.vim/after/plugin/lsp.vim`, and with `g:lsp_enable` true and false in `vimrc`. 

Using both typescript language server and jedi language server in the same Vim session the behaviour is as expected:

* When Vim started with `g:lsp_enable = true`, language servers start automatically as files are opened for editing. Calling `g:LspDisable()` disables LSP for all currently opened files and any additional files opened for editing, but does not stop any running LSP servers. Calling `g:LspEnable()` resumes LSP for all opened files.

* When  Vim started with `g:lsp_enable = false`, no language servers are started automatically as files are opened for editing. Calling `g:LspEnable()` starts language servers and enables LSP features for all opened files.

* `g:LspEnable()` and `g:LspDisable()` can be used to toggle LSP features on and off for all opened files.

Also tested with Debian docker container using Vim 9.1.0016 and `clangd`, works as expected. This was using a minimal vim config, just vim-sensible and lsp.

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [X] No  

I don't think so, but would appreciate some additional testing. Works fine for me on MacOS and Debian.

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [X] No 

I have updated the docs

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [X] I have run the plugin against the relevant LSP server(s).
- [X] I have updated documentation if needed.
- [X] I have followed the project’s coding style and conventions.
- [x] I have added tests or examples where appropriate.

