### PR TITLE
Handle push diagnostics even if pull is enabled

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -166,7 +166,12 @@ def DeduplicateDiags(diags: list<dict<any>>): list<dict<any>>
   var result = []
   var seen = {}
   for d in diags
-    var key = $"{d.range.start.line}:{d.range.start.character}:{d->get('code', '')->string()}:{d.message}"
+    var key = string([
+      d.range.start.line,
+      d.range.start.character,
+      d->get('code', ''),
+      d.message
+    ])
     if !seen->has_key(key)
       seen[key] = true
       result->add(d)

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -440,7 +440,18 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
   endif
   var bnr: number = fname->bufnr()
 
-  var newDiags: list<dict<any>> = diags_arg->slice(0, opt.lspOptions.maxDiagnostics)
+  var serverId = lspserver.id
+  var serverDiags: dict<dict<list<any>>> = diagsMap->has_key(bnr) ?
+      diagsMap[bnr].serverDiagnostics : {}
+  var kindDiags: dict<list<any>> = serverDiags->has_key(serverId) ?
+      serverDiags[serverId] : {}
+
+  # Count existing diagnostics from this server for other sync kinds
+  var otherDiagCount = kindDiags
+      ->keys()
+      ->filter((_, k) => k != sync_kind)
+      ->reduce((acc, k) => acc + kindDiags[k]->len(), 0)
+  var newDiags: list<dict<any>> = diags_arg->slice(0, opt.lspOptions.maxDiagnostics - otherDiagCount)
 
   if lspserver.needOffsetEncoding
     # Decode the position encoding in all the diags
@@ -456,12 +467,6 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
 
   # TODO: Is the buffer (bnr) always a loaded buffer? Should we load it here?
   var lastlnum: number = bnr->getbufinfo()[0].linecount
-
-  var serverId = lspserver.id
-  var serverDiags: dict<dict<list<any>>> = diagsMap->has_key(bnr) ?
-      diagsMap[bnr].serverDiagnostics : {}
-  var kindDiags: dict<list<any>> = serverDiags->has_key(serverId) ?
-      serverDiags[serverId] : {}
   kindDiags[sync_kind] = newDiags
   serverDiags[serverId] = kindDiags
 

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -8,8 +8,14 @@ import './util.vim'
 
 # [bnr] = {
 #   serverDiagnostics: {
-#     lspServer1Id: [diag, diag, diag]
-#     lspServer2Id: [diag, diag, diag]
+#     lspServer1Id: {
+#       push: [diag, diag, diag],
+#       pull: [diag, diag, diag]
+#     },
+#     lspServer2Id: {
+#       push: [diag, diag, diag],
+#       pull: [diag, diag, diag]
+#     }
 #   },
 #   serverDiagnosticsByLnum: {
 #     lspServer1Id: { [lnum]: [diag, diag diag] },
@@ -152,6 +158,24 @@ enddef
 # Sort diagnostics ascending based on line and character offset
 def SortDiags(diags: list<dict<any>>): list<dict<any>>
   return diags->sort(DiagsSortFunc)
+enddef
+
+# Deduplicate diagnostics, if the same dignostic is sent in
+# both push and pull channels
+def DeduplicateDiags(diags: list<dict<any>>): list<dict<any>>
+  var result = []
+  var seen = {}
+  for d in diags
+    var key = printf('%d:%d:%s:%s',
+                     d.range.start.line, d.range.start.character,
+                     d->get('code', '')->string(), d.message)
+    if !seen->has_key(key)
+      seen[key] = true
+      result->add(d)
+    endif
+  endfor
+
+  return result
 enddef
 
 # Remove the diagnostics stored for buffer "bnr"
@@ -401,7 +425,7 @@ enddef
 # process a diagnostic notification message from the LSP server
 # Notification: textDocument/publishDiagnostics
 # Param: PublishDiagnosticsParams
-export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<dict<any>>): void
+export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<dict<any>>, channel: string): void
   # Diagnostics are disabled for this server?
   if !lspserver.featureEnabled('diagnostics')
     return
@@ -430,11 +454,23 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
   # TODO: Is the buffer (bnr) always a loaded buffer? Should we load it here?
   var lastlnum: number = bnr->getbufinfo()[0].linecount
 
+  var serverId = lspserver.id->string()
+  var serverDiags: dict<dict<list<any>>> = diagsMap->has_key(bnr) ?
+      diagsMap[bnr].serverDiagnostics : {}
+  var channelDiags: dict<list<any>> = serverDiags->has_key(serverId) ?
+      serverDiags[serverId] : {}
+  channelDiags[channel] = newDiags
+  serverDiags[serverId] = channelDiags
+
+  var dedupedDiags = []
+  for diags in channelDiags->values()
+    dedupedDiags->extend(diags)
+    dedupedDiags = DeduplicateDiags(dedupedDiags)
+  endfor
+
   # store the diagnostic for each line separately
   var diagsByLnum: dict<list<dict<any>>> = {}
-
-  var diagWithinRange: list<dict<any>> = []
-  for diag in newDiags
+  for diag in dedupedDiags
     var d_start = diag.range.start
     if d_start.line + 1 > lastlnum
       # Make sure the line number is a valid buffer line number
@@ -446,22 +482,18 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
       diagsByLnum[lnum] = []
     endif
     diagsByLnum[lnum]->add(diag)
-
-    diagWithinRange->add(diag)
   endfor
-
-  var serverDiags: dict<list<any>> = diagsMap->has_key(bnr) ?
-      diagsMap[bnr].serverDiagnostics : {}
-  serverDiags[lspserver.id] = diagWithinRange
 
   var serverDiagsByLnum: dict<dict<list<any>>> = diagsMap->has_key(bnr) ?
       diagsMap[bnr].serverDiagnosticsByLnum : {}
-  serverDiagsByLnum[lspserver.id] = diagsByLnum
+  serverDiagsByLnum[serverId] = diagsByLnum
 
   # store the diagnostic for each line separately
   var joinedServerDiags: list<dict<any>> = []
-  for diags in serverDiags->values()
-    joinedServerDiags->extend(diags)
+  for chanDiags in serverDiags->values()
+    for diags in chanDiags->values()
+      joinedServerDiags->extend(diags)
+    endfor
   endfor
 
   var sortedDiags = SortDiags(joinedServerDiags)

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -160,15 +160,13 @@ def SortDiags(diags: list<dict<any>>): list<dict<any>>
   return diags->sort(DiagsSortFunc)
 enddef
 
-# Deduplicate diagnostics, if the same dignostic is sent in
+# Deduplicate diagnostics, if the same diagnostic is sent in
 # both push and pull channels
 def DeduplicateDiags(diags: list<dict<any>>): list<dict<any>>
   var result = []
   var seen = {}
   for d in diags
-    var key = printf('%d:%d:%s:%s',
-                     d.range.start.line, d.range.start.character,
-                     d->get('code', '')->string(), d.message)
+    var key = $"{d.range.start.line}:{d.range.start.character}:{d->get('code', '')->string()}:{d.message}"
     if !seen->has_key(key)
       seen[key] = true
       result->add(d)
@@ -425,7 +423,7 @@ enddef
 # process a diagnostic notification message from the LSP server
 # Notification: textDocument/publishDiagnostics
 # Param: PublishDiagnosticsParams
-export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<dict<any>>, channel: string): void
+export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<dict<any>>, sync_kind: string): void
   # Diagnostics are disabled for this server?
   if !lspserver.featureEnabled('diagnostics')
     return
@@ -454,19 +452,19 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
   # TODO: Is the buffer (bnr) always a loaded buffer? Should we load it here?
   var lastlnum: number = bnr->getbufinfo()[0].linecount
 
-  var serverId = lspserver.id->string()
+  var serverId = lspserver.id
   var serverDiags: dict<dict<list<any>>> = diagsMap->has_key(bnr) ?
       diagsMap[bnr].serverDiagnostics : {}
   var channelDiags: dict<list<any>> = serverDiags->has_key(serverId) ?
       serverDiags[serverId] : {}
-  channelDiags[channel] = newDiags
+  channelDiags[sync_kind] = newDiags
   serverDiags[serverId] = channelDiags
 
   var dedupedDiags = []
   for diags in channelDiags->values()
     dedupedDiags->extend(diags)
-    dedupedDiags = DeduplicateDiags(dedupedDiags)
   endfor
+  dedupedDiags = DeduplicateDiags(dedupedDiags)
 
   # store the diagnostic for each line separately
   var diagsByLnum: dict<list<dict<any>>> = {}

--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -460,13 +460,13 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
   var serverId = lspserver.id
   var serverDiags: dict<dict<list<any>>> = diagsMap->has_key(bnr) ?
       diagsMap[bnr].serverDiagnostics : {}
-  var channelDiags: dict<list<any>> = serverDiags->has_key(serverId) ?
+  var kindDiags: dict<list<any>> = serverDiags->has_key(serverId) ?
       serverDiags[serverId] : {}
-  channelDiags[sync_kind] = newDiags
-  serverDiags[serverId] = channelDiags
+  kindDiags[sync_kind] = newDiags
+  serverDiags[serverId] = kindDiags
 
   var dedupedDiags = []
-  for diags in channelDiags->values()
+  for diags in kindDiags->values()
     dedupedDiags->extend(diags)
   endfor
   dedupedDiags = DeduplicateDiags(dedupedDiags)
@@ -487,16 +487,21 @@ export def DiagNotification(lspserver: dict<any>, uri: string, diags_arg: list<d
     diagsByLnum[lnum]->add(diag)
   endfor
 
+  # store the diagnostic for each line separately
   var serverDiagsByLnum: dict<dict<list<any>>> = diagsMap->has_key(bnr) ?
       diagsMap[bnr].serverDiagnosticsByLnum : {}
   serverDiagsByLnum[serverId] = diagsByLnum
 
-  # store the diagnostic for each line separately
   var joinedServerDiags: list<dict<any>> = []
-  for chanDiags in serverDiags->values()
-    for diags in chanDiags->values()
-      joinedServerDiags->extend(diags)
+  for kndDiags in serverDiags->values()
+    # De-duplicate diagnostics across push and pull for each server
+    var dedupedServerDiags = []
+    for diags in kndDiags->values()
+      dedupedServerDiags->extend(diags)
     endfor
+    dedupedServerDiags = DeduplicateDiags(dedupedServerDiags)
+
+    joinedServerDiags->extend(dedupedServerDiags)
   endfor
 
   var sortedDiags = SortDiags(joinedServerDiags)

--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -13,14 +13,8 @@ import './buffer.vim' as buf
 # Notification: textDocument/publishDiagnostics
 # Param: PublishDiagnosticsParams
 def ProcessDiagNotif(lspserver: dict<any>, reply: dict<any>): void
-  # For pull-capable servers, diagnostics come from textDocument/diagnostic.
-  # Ignore push notifications from such servers.
-  if lspserver.isDiagnosticsProvider
-    return
-  endif
-
   var params = reply.params
-  diag.DiagNotification(lspserver, params.uri, params.diagnostics)
+  diag.DiagNotification(lspserver, params.uri, params.diagnostics, 'push')
 enddef
 
 # Convert LSP message type to a string

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -819,7 +819,7 @@ def PullDiagnostics(lspserver: dict<any>, bnr: number)
     if items->empty() && waitForInitialProgress
       return
     endif
-    diag.DiagNotification(lspserver, uri, items)
+    diag.DiagNotification(lspserver, uri, items, 'pull')
   elseif reportKind != 'unchanged'
     util.WarnMsg($'Unsupported diagnostic report kind "{reportKind}"')
   endif


### PR DESCRIPTION
## 📌 Summary

Some LSP servers, like rust-analyzer, send diagnostic items through both push and pull channels. While rust-analyzer sends a disjoint set of diagnostics through the two channels, the LSP specification doesn't appear to mandate this. Hence the same diagnostic item may be sent through push and pull by some LSP servers.

This change handles pushed diagnostic items, even if the server supports pull. Additionally, it maintains separate lists for diagnostic items receive through push and pull. It deduplicates items across the two channels, using start line, start character, code, and message of the items.

---

## 🔍 Related Issues

Fixes #798

---

## 🧪 What This PR Improves

Before this change diagnostics sent through push were not visible, if the server supported `diagnosticProvider` capability.

---

## 🛠️ Changes Made

- Handle pushed diagnostic items, even if the server supports pull, by maintaining separate lists for push and pull.
- Deduplicate items across push and pull, using start line, start character, code, and message of the items.

---

## 🧪 Testing

With `rust-analyzer` configured as an LSP server, test the following scenarios.

### Push Diagnostics

Add the following lines in main.rs, write it with `:w`, and observe that a diagnostic item is displayed for missing import of `HashMap` on line #2.

```
fn main() {
    HashMap::new();
}
```

### Pull Diagnostics

Add the following lines in main.rs and observe that a diagnostic item is displayed for missing semicolon on line #2.

```
use std::collections::HashMap;

fn main() {
    let _map: HashMap<i64, i64> = HashMap::new()
    println!("Hello, world!");
}
```

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No 

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [x] No  

If yes, describe what needs updating.

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [ ] I have updated documentation if needed.
- [x] I have followed the project’s coding style and conventions.
- [ ] I have added tests or examples where appropriate.

