### PR TITLE
Handle empty string in textDocument/completion response

### DIFF
--- a/autoload/lsp/completion.vim
+++ b/autoload/lsp/completion.vim
@@ -167,7 +167,7 @@ def ApplyCompletionItemLabelDetails(item: dict<any>, d: dict<any>)
 
   var detailText = labelDetails->get('detail', v:none)
   if detailText->type() == v:t_string
-    var detailLine = detailText->split("\n")[0]
+    var detailLine = detailText->empty() ? '' : detailText->split("\n")[0]
     if !detailLine->empty()
       d.abbr ..= detailLine
     endif
@@ -178,7 +178,7 @@ def ApplyCompletionItemLabelDetails(item: dict<any>, d: dict<any>)
     return
   endif
 
-  var descLine = descText->split("\n")[0]
+  var descLine = descText->empty() ? '' : descText->split("\n")[0]
   if descLine->empty()
     return
   endif

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -505,7 +505,7 @@ def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel,
   try
     RpcCb(lspserver, result, error)
   catch
-    lspserver.errorLog($'Callback for {method} raised exception: {v:exception} stack trace:{v:stacktrace}')
+    lspserver.errorLog($'Callback for {method} raised exception: {v:exception}')
   endtry
 enddef
 

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -505,7 +505,7 @@ def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel,
   try
     RpcCb(lspserver, result, error)
   catch
-    lspserver.errorLog($'Callback for {method} raised exception: {v:exception}')
+    lspserver.errorLog($'Callback for {method} raised exception: {v:exception} stack trace:{v:stacktrace}')
   endtry
 enddef
 


### PR DESCRIPTION
## 📌 Summary

Some language serer(e.g. https://github.com/DanielGavin/ols) may return empty string in textDocument/completion response. 

<details>
<summary>Example response with empty `detail` and  `description`</summary>

```json
{
  "id": 3,
  "jsonrpc": "2.0",
  "result": {
    "isIncomplete": true,
    "items": [
      {
        "label": "_user_formatters",
        "tags": [],
        "deprecated": false,
        "sortText": "00000",
        "kind": 6,
        "documentation": {
          "kind": "markdown",
          "value": "```odin\nfmt._user_formatters: ^map[typeid]User_Formatter\n```\n---\nNOTE(bill): This is a pointer to prevent accidental additions\nit is prefixed with `_` rather than marked with a private attribute so that users can access it if necessary"
        },
        "labelDetails": {
          "description": "^map[typeid]User_Formatter",
          "detail": ""
        },
        "detail": "^map[typeid]User_Formatter"
      },
      {
        "label": "aprint",
        "tags": [],
        "deprecated": false,
        "sortText": "00005",
        "kind": 3,
        "documentation": {
          "kind": "markdown",
          "value": "```odin\n@(require_results)\nfmt.aprint :: proc(args: ..any, sep := \" \", allocator := context.allocator) -> string\n```\n---\nCreates a formatted string\n\n*Allocates Using Provided Allocator*\n\nInputs:\n- args: A variadic list of arguments to be formatted.\n- sep: An optional separator string (default is a single space).\n- allocator: (default: context.allocator)\n\nReturns: A formatted string. \n"
        },
        "labelDetails": {
          "description": "",
          "detail": "(args: ..any, sep := \" \", allocator := context.allocator) -> string"
        },
        "detail": "(args: ..any, sep := \" \", allocator := context.allocator) -> string"
      },



```

</details>

---

## 🔍 Related Issues


none

---

## 🧪 What This PR Improves

- Handle empty 'detail' and 'description' in ApplyCompletionItemLabelDetails.
- Also log `v:stacktrace` on error. 

If you don't like the stacktrace, I can revert it.

---

## 🛠️ Changes Made

Same as last part

---

## 🧪 Testing

```vim
vim9script

var lsp_servers: list<dict<any>> = []

  lsp_servers->add({
    name: 'ols',
    filetype: ['odin'],
    path: 'ols',
    rootSearch: ['ols.json'],
  })


var lsp_options = {
  autoComplete: false,
  omniComplete: true,
  # completionMatcher: 'fuzzy',
  usePopupInCodeAction: true,
  showSignature: false,
  semanticHighlight: false,
  condensedCompletionMenu: true,
  useQuickfixForLocations: true,
  ignoreCompleteItemsIsIncomplete: ['rustanalyzer', 'ols'],

  popupBorder: true,
  popupBorderChars: ['─', '│', '─', '│', '┌', '┐', '┘', '└'],
  popupBorderHighlight: 'Identifier',
  popupHighlight: 'Normal',
  popupBorderSignatureHelp: false,
  popupHighlightSignatureHelp: 'Pmenu',
}
g:LspOptionsSet(lsp_options)
g:LspAddServer(lsp_servers)
```



```odin
package main

import "core:fmt"


main :: proc() {
	fmt.
}
```
Configure ols and complete at `fmt.`


---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

If yes, explain:

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [x] No  

If yes, describe what needs updating.

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [x] I have updated documentation if needed.
- [x] I have followed the project’s coding style and conventions.
- [x] I have added tests or examples where appropriate.

