### PR TITLE
Backwards compatibility for async RPC callback

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -505,7 +505,16 @@ def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel,
   try
     RpcCb(lspserver, result, error)
   catch
-    lspserver.errorLog($'Callback for {method} raised exception: {v:exception}')
+    # backwards compatibility for old callback signature
+    if v:exception =~# '\v:(E118):' && v:throwpoint =~# 'AsyncRpcCb'
+      try
+        RpcCb(lspserver, result)
+      catch
+        lspserver.errorLog($'Callback for {method} raised exception: {v:exception}')
+      endtry
+    else
+      lspserver.errorLog($'Callback for {method} raised exception: {v:exception}')
+    endif
   endtry
 enddef
 

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -506,7 +506,7 @@ def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel,
     RpcCb(lspserver, result, error)
   catch
     # backwards compatibility for old callback signature
-    if v:exception =~# '\v:(E118):' && v:throwpoint =~# 'AsyncRpcCb'
+    if v:exception =~# '\v:(E118):' && v:throwpoint =~# 'AsyncRpcCb,\s\+line\s\+\d'
       try
         RpcCb(lspserver, result)
       catch


### PR DESCRIPTION
The signature for the callback function was changed to require an error argument in commit f396fe75b7e7be4cc3e703641905c90d41c767b4, but this is a breaking change not reflected in the lsp-custom-requests documentation

This restores compatibility with plugins like fuzzbox-lsp.vim and scope.vim, and anyone who has followed the docs for custom requests.