### PR TITLE
Improve backwards compat for async RPC callback

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -473,6 +473,13 @@ def Rpc(lspserver: dict<any>, method: string, params: any, opts: dict<any> = {})
   return {}
 enddef
 
+# legacy script function to get v:stacktrace to avoid function compile errors on
+# Vim versions that do not include it (only added to Vim in version 9.1.0984)
+# get(v:, 'stacktrace') in a vim9 function throws E1075: Namespace not supported: v:, 'stacktrace'
+function GetStackTrace()
+  return get(v:, 'stacktrace')
+endfunction
+
 # LSP server asynchronous RPC callback
 def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel, reply: dict<any>)
   if lspserver.debug
@@ -507,7 +514,7 @@ def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel,
   catch
     # backwards compatibility for old callback signature
     if v:exception =~# '\v:(E118):' && (
-	( exists('v:stacktrace') && expand('<script>:p') == v:stacktrace[-1]['filepath'] )
+	( exists('v:stacktrace') && expand('<script>:p') == GetStackTrace()[-1]['filepath'] )
 	|| v:throwpoint =~# 'AsyncRpcCb,\s\+line\s\+\d' )
       try
         RpcCb(lspserver, result)

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -506,7 +506,9 @@ def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel,
     RpcCb(lspserver, result, error)
   catch
     # backwards compatibility for old callback signature
-    if v:exception =~# '\v:(E118):' && v:throwpoint =~# 'AsyncRpcCb,\s\+line\s\+\d'
+    if v:exception =~# '\v:(E118):' && (
+	( exists('v:stacktrace') && expand('<script>:p') == v:stacktrace[-1]['filepath'] )
+	|| v:throwpoint =~# 'AsyncRpcCb,\s\+line\s\+\d' )
       try
         RpcCb(lspserver, result)
       catch


### PR DESCRIPTION
## 📌 Summary

Use `v:stacktrace` if available to check call site when handling "Too many arguments" error and support previously async RPC callback function signature.

---

## 🔍 Related Issues

- Related to #807

---

## 🧪 What This PR Improves

More reliably checks that the "Too many arguments" error occurred within the LSP server code rather than in the callback code itself when falling back to using the old function signature.

---

## 🛠️ Changes Made

- If `v:stacktrace` exists, confirm that the current script path matches the last filepath in the stacktrace before falling back to the old callback function signature
- If `v:stacktrace` does not exist, continue to pattern match on `v:throwpoint`, as before

---

## 🧪 Testing

Manually tested locally with fuzzbox-lsp.vim

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

If yes, explain:

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [X] No  

---

## ✔️ Checklist

- [X] I have tested this with a minimal Vim9script configuration.
- [X] I have run the plugin against the relevant LSP server(s).
- [X] I have updated documentation if needed.
- [X] I have followed the project’s coding style and conventions.
- [X] I have added tests or examples where appropriate.

