### PR TITLE
Improve backwards compat for async RPC callback

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -506,7 +506,15 @@ def AsyncRpcCb(lspserver: dict<any>, method: string, RpcCb: func, chan: channel,
     RpcCb(lspserver, result, error)
   catch
     # backwards compatibility for old callback signature
-    if v:exception =~# '\v:(E118):' && v:throwpoint =~# 'AsyncRpcCb,\s\+line\s\+\d'
+    var retry: bool = false
+    if v:exception =~# '\v:(E118):'
+      if exists_compiled('v:stacktrace')
+	retry = expand('<script>:p') == v:stacktrace[-1]['filepath']
+      else
+	retry = v:throwpoint =~# 'AsyncRpcCb,\s\+line\s\+\d'
+      endif
+    endif
+    if retry
       try
         RpcCb(lspserver, result)
       catch


### PR DESCRIPTION
## 📌 Summary

Use `v:stacktrace` if available to check call site when handling "Too many arguments" error and support previously async RPC callback function signature.

---

## 🔍 Related Issues

- Related to #807

---

## 🧪 What This PR Improves

More reliably checks that the "Too many arguments" error occurred within the LSP server code rather than in the callback code itself when falling back to using the old function signature.

---

## 🛠️ Changes Made

- If `v:stacktrace` exists, confirm that the current script path matches the last filepath in the stacktrace before falling back to the old callback function signature
- If `v:stacktrace` does not exist, continue to pattern match on `v:throwpoint`, as before

---

## 🧪 Testing

Manually tested locally with fuzzbox-lsp.vim using Vim 9.0.0000 and 9.2.0421

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [X] No  

---

## ✔️ Checklist

- [X] I have tested this with a minimal Vim9script configuration.
- [X] I have run the plugin against the relevant LSP server(s).
- [X] I have updated documentation if needed.
- [X] I have followed the project’s coding style and conventions.
- [X] I have added tests or examples where appropriate.