### PR TITLE
fix(diag): diagnostic messages shouldn't have CR

### DIFF
--- a/autoload/lsp/diag.vim
+++ b/autoload/lsp/diag.vim
@@ -341,7 +341,7 @@ export def DiagsRefresh(bnr: number, all: bool = false)
 
         prop_add(lnum, 0, {bufnr: bnr,
 			   type: DiagSevToVirtualTextHLName(d_severity),
-                           text: $'{symbol} {diag.message}',
+                           text: $'{symbol} {diag.msg}',
                            text_align: diag_align,
                            text_wrap: diag_wrap,
                            text_padding_left: padding})
@@ -593,7 +593,7 @@ def DiagsUpdateLocList(bnr: number, calledByCmd: bool = false): bool
     var d_range = diag.range
     var d_start = d_range.start
     var d_end = d_range.end
-    text = diag.message->substitute("\n\\+", "\n", 'g')
+    text = diag.msg
     qflist->add({filename: fname,
 		    lnum: d_start.line + 1,
 		    col: util.GetLineByteFromPos(bnr, d_start) + 1,
@@ -723,7 +723,7 @@ def ShowCurrentDiagInStatusLine()
       code = $'[{diag.code}] '
     endif
     var msgNoLineBreak = code ..
-	diag.message->substitute("[[:cntrl:]]", ' ', 'g')
+	diag.msg
     :echo msgNoLineBreak[ : max_width]
   else
     # clear the previous message

--- a/autoload/lsp/handlers.vim
+++ b/autoload/lsp/handlers.vim
@@ -14,6 +14,14 @@ import './buffer.vim' as buf
 # Param: PublishDiagnosticsParams
 def ProcessDiagNotif(lspserver: dict<any>, reply: dict<any>): void
   var params = reply.params
+  for i in params.diagnostics
+    var len = i.message->stridx("\n")
+    if len != -1
+      i.msg = i.message->strpart(0, len)
+    else
+      i.msg = i.message
+    endif
+  endfor
   diag.DiagNotification(lspserver, params.uri, params.diagnostics, 'push')
 enddef
 


### PR DESCRIPTION
Especially in virtual text and quickfix window.

## 📌 Summary

Previously, things with '\n' will also being shown in location list and virtual text. Which is ugly and unhelpful. Other lsp plugins like nvim also didn't show it in virtual text.
<img width="1123" height="31" alt="图片" src="https://github.com/user-attachments/assets/e1006cf1-ac1b-4d6a-9485-0ae34150f6a3" />

Now it only show one single line.
<img width="502" height="45" alt="图片" src="https://github.com/user-attachments/assets/366c54d2-8915-4842-9a7c-916eb93f6ef0" />

Still show complete message in `:LspDiagCurrent`
<img width="994" height="175" alt="图片" src="https://github.com/user-attachments/assets/27ab15bb-8aa4-4415-89b1-08784ca4f0f5" />

## 🧪 Testing

I didn't know whether this is the right behaviour.
---

## 📦 Breaking Changes

- [x] Yes