### PR TITLE
Handle multiple servers at startup (#817)

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -685,11 +685,6 @@ enddef
 
 # A new buffer is opened. If LSP is supported for this buffer, then add it
 export def AddFile(bnr: number): void
-  if buf.BufHasLspServer(bnr)
-    # LSP server for this buffer is already initialized and running
-    return
-  endif
-
   # Skip remote files
   if util.LspUriRemote(bnr->bufname()->fnamemodify(':p'))
     return
@@ -711,9 +706,18 @@ export def AddFile(bnr: number): void
   endif
 
   # Start all the lsp servers registered for this buffer file type (if needed)
+  var attachedServerIds: list<number> = buf.BufLspServersGet(bnr)
+    ->copy()
+    ->filter((_, lspsrv) => !lspsrv->empty())
+    ->map((_, lspsrv) => lspsrv.id)
   var attachedServers: list<dict<any>> = []
   for lspserver in lspservers
     if lspserver.stoppedByUser
+      continue
+    endif
+
+    if attachedServerIds->index(lspserver.id) != -1
+      # This server is already attached to the buffer
       continue
     endif
 


### PR DESCRIPTION
AddFile skips adding servers if ANY ONE server was already running on a buffer. This prevents running multiple servers on one buffer at startup. Replace this short-circuit with a check against EACH server to prevent attaching the same server multiple times.

## 📌 Summary

Provide a clear and concise description of the changes in this PR.

---

## 🔍 Related Issues

Link any related issues or discussions:

- Closes #817
- Related to #

---

## 🧪 What This PR Improves

Multiple LSP servers would attach when opening a file with `:e file.py`, but not when starting Vim with `vim file.py`.

---

## 🛠️ Changes Made

List the key changes:

- Removed short-circuit in AddFile that checked if ANY ONE server is attached.
- Added short-circuit to check for EACH server.
- 

---

## 🧪 Testing

Describe how you tested the changes. Include steps, commands, or sample files.

# Steps to verify behavior
# If applicable, include screenshots or logs.

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

If yes, explain:

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [x] No  

If yes, describe what needs updating.

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [x] I have updated documentation if needed. (N/A)
- [x] I have followed the project’s coding style and conventions.
- [x] I have added tests or examples where appropriate. (N/A)

