### PR TITLE
Match Win paths like `fugitive:\\\C:\...` in LspUriRemote

### DIFF
--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -185,7 +185,8 @@ enddef
 # Returns if the URI refers to a remote file (e.g. ssh://)
 # Credit: vim-lsp plugin
 export def LspUriRemote(uri: string): bool
-  return uri =~ '^\w\+::' || uri =~ '^[a-z][a-z0-9+.-]*://'
+  var normalized_uri = uri->substitute('\\', '/', 'g')
+  return normalized_uri =~ '^\w\+::' || normalized_uri =~ '^[a-z][a-z0-9+.-]*://'
 enddef
 
 var resolvedUris = {}


### PR DESCRIPTION
`LspUriRemote` attempts to match on `'^[a-z][a-z0-9+.-]*://'`, but this fails on Windows paths. This leads to mis-identifying non-files like `fugitive:\\\...`. Normalize to forward slashes before matching.

## 📌 Summary

Normalize Windows paths to forward slashes in order to correctly match remote-file identification in `LspUriRemote`.

---

## 🔍 Related Issues

Link any related issues or discussions:

- Closes #
- Related to #  [https://github.com/yegappan/lsp/issues/805](https://github.com/yegappan/lsp/issues/805). Probably closes it.

---

## 🧪 What This PR Improves

This will stop servers from vomiting errors when running fugitive's `:G difftool -y` as the servers attempt and fail to connect to fugitive buffers.

---

## 🛠️ Changes Made

List the key changes:

- 
- 
- 

---

## 🧪 Testing

Describe how you tested the changes. Include steps, commands, or sample files.

# Steps to verify behavior
# If applicable, include screenshots or logs.

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

If yes, explain:

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [x] No  

If yes, describe what needs updating.

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [x] I have updated documentation if needed.
- [x] I have followed the project’s coding style and conventions.
- [ ] I have added tests or examples where appropriate.

