### PR TITLE
On type formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ call LspOptionsSet(#{
         \   maxDiagnostics: 200,
         \   omniComplete: v:null,
         \   omniCompleteAllowBare: v:false,
+        \   onTypeFormatting: v:false,
         \   outlineOnRight: v:false,
         \   outlineWinSize: 20,
         \   popupBorder: v:true,

--- a/autoload/lsp/buffer.vim
+++ b/autoload/lsp/buffer.vim
@@ -44,6 +44,7 @@ var SupportedCheckFns = {
   diagnostics: (lspserver) => lspserver.isDiagnosticsProvider,
   definition: (lspserver) => lspserver.isDefinitionProvider,
   documentFormatting: (lspserver) => lspserver.isDocumentFormattingProvider,
+  documentOnTypeFormatting: (lspserver) => lspserver.isDocumentOnTypeFormattingProvider,
   documentRangeFormatting: (lspserver) => lspserver.isDocumentRangeFormattingProvider,
   documentHighlight: (lspserver) => lspserver.isDocumentHighlightProvider,
   documentSymbol: (lspserver) => lspserver.isDocumentSymbolProvider,

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -268,9 +268,14 @@ export def ProcessServerCaps(lspserver: dict<any>, caps: dict<any>)
 
   # documentOnTypeFormattingProvider
   if lspserver.caps->has_key('documentOnTypeFormattingProvider')
-      lspserver.isDocumentOnTypeFormattingProvider = true
+    lspserver.isDocumentOnTypeFormattingProvider = true
+    var onTypeProvider = lspserver.caps.documentOnTypeFormattingProvider
+    lspserver.onTypeFormattingTriggers =
+	[onTypeProvider.firstTriggerCharacter] +
+	onTypeProvider->get('moreTriggerCharacter', [])
   else
-      lspserver.isDocumentOnTypeFormattingProvider = false
+    lspserver.isDocumentOnTypeFormattingProvider = false
+    lspserver.onTypeFormattingTriggers = []
   endif
 
   # renameProvider

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -562,6 +562,9 @@ export def GetClientCaps(): dict<any>
       inlayHint: {
 	dynamicRegistration: false
       },
+      onTypeFormatting: {
+	dynamicRegistration: false
+      },
       publishDiagnostics: {
 	relatedInformation: false,
 	versionSupport: true,

--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -23,6 +23,7 @@ import './codeaction.vim'
 import './hover.vim'
 import './inlayhints.vim'
 import './semantichighlight.vim'
+import './ontypeformat.vim'
 
 # filetype to LSP server map
 var ftypeServerMap: dict<list<dict<any>>> = {}
@@ -53,6 +54,7 @@ def LspInitOnce()
   signature.InitOnce()
   symbol.InitOnce()
   semantichighlight.InitOnce()
+  ontypeformat.InitOnce()
 
   lspInitializedOnce = true
 enddef
@@ -663,6 +665,11 @@ def BufferInit(lspserverId: number, bnr: number): void
       var semanticServer = buf.BufLspServerGet(bnr, 'semanticTokens')
       if !semanticServer->empty() && lspsrv.id == semanticServer.id
 	semantichighlight.BufferInit(lspserver, bnr)
+      endif
+
+      var onTypeFormatServer = buf.BufLspServerGet(bnr, 'documentOnTypeFormatting')
+      if !onTypeFormatServer->empty() && lspsrv.id == onTypeFormatServer.id
+	ontypeformat.BufferInit(lspsrv, bnr)
       endif
     endfor
 
@@ -1347,8 +1354,8 @@ export def TextDocFormat(range_args: number, line1: number, line2: number)
   endif
 enddef
 
-# TODO: Add support for textDocument.onTypeFormatting?
-# Will this slow down Vim?
+# Support for textDocument/onTypeFormatting is implemented in
+# autoload/lsp/ontypeformat.vim (opt-in via the 'onTypeFormatting' option).
 
 # Display all the locations where the current symbol is called from.
 # Uses LSP "callHierarchy/incomingCalls" request

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1549,6 +1549,9 @@ def TextDocOnTypeFormat(lspserver: dict<any>, ch: string)
     return
   endif
 
+  # Send the pending buffer changes to the language server
+  bnr->listener_flush()
+
   # interface DocumentOnTypeFormattingParams
   #   interface TextDocumentIdentifier
   #   interface Position

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -1482,6 +1482,111 @@ def TextDocFormat(lspserver: dict<any>, fname: string, rangeFormat: bool,
   textedit.ApplyTextEdits(bnr, reply.result)
 enddef
 
+# Adjust 'origPos' (a decoded, 0-indexed {line, character} position) to
+# account for having applied 'edits' (also decoded, in original-document
+# order/coordinates) to the buffer.
+#
+# textedit.ApplyTextEdits() does not track cursor movement.  On-type
+# formatting edits routinely insert text immediately before the just-typed
+# character (e.g. indenting the line the server just reformatted), so the
+# cursor needs to be moved past that inserted text to keep typing naturally.
+# Only edits that end at or before 'origPos' are relevant here: on-type
+# formatting edits are always local to the trigger point.
+def AdjustPositionForOnTypeEdits(origPos: dict<number>,
+				 edits: list<dict<any>>): dict<number>
+  var sorted = edits->copy()->sort((a, b) => {
+    if a.range.start.line != b.range.start.line
+      return a.range.start.line - b.range.start.line
+    endif
+    return a.range.start.character - b.range.start.character
+  })
+
+  var lineDelta = 0
+  var character = origPos.character
+  var adjustedOnOrigLine = false
+
+  for e in sorted
+    var s = e.range.start
+    var en = e.range.end
+    if en.line > origPos.line
+	|| (en.line == origPos.line && en.character > origPos.character)
+      # This edit is at or after 'origPos'; on-type formatting edits are
+      # expected to precede the just-typed character.
+      continue
+    endif
+
+    var newTextLines = e.newText->split("\n", true)
+    lineDelta += (newTextLines->len() - 1) - (en.line - s.line)
+
+    if en.line == origPos.line
+      if newTextLines->len() == 1
+	character = character - en.character + s.character +
+					newTextLines[0]->strcharlen()
+      else
+	character = character - en.character + newTextLines[-1]->strcharlen()
+      endif
+      adjustedOnOrigLine = true
+    endif
+  endfor
+
+  return {line: origPos.line + lineDelta,
+	  character: adjustedOnOrigLine ? character : origPos.character}
+enddef
+
+# Request on-type formatting edits for the character just typed and apply
+# them to the buffer, then place the cursor after any inserted text so that
+# typing can continue naturally.
+# Request: "textDocument/onTypeFormatting"
+# Param: DocumentOnTypeFormattingParams
+def TextDocOnTypeFormat(lspserver: dict<any>, ch: string)
+  if !lspserver.isDocumentOnTypeFormattingProvider
+    util.ErrMsg('LSP server does not support on-type formatting')
+    return
+  endif
+
+  var bnr: number = @%->bufnr()
+  if bnr == -1
+    return
+  endif
+
+  # interface DocumentOnTypeFormattingParams
+  #   interface TextDocumentIdentifier
+  #   interface Position
+  #   ch: string
+  #   interface FormattingOptions
+  var param = lspserver.getTextDocPosition(false)
+  param.ch = ch
+  param.options = {
+    tabSize: shiftwidth(),
+    insertSpaces: &expandtab ? true : false,
+  }
+  var origPos = param.position->copy()
+
+  var reply = lspserver.rpc('textDocument/onTypeFormatting', param)
+
+  # result: TextEdit[] | null
+  if reply->empty() || reply.result->empty()
+    return
+  endif
+
+  if lspserver.needOffsetEncoding
+    reply.result->map((_, textEdit) => {
+      lspserver.decodeRange(bnr, textEdit.range)
+      return textEdit
+    })
+    lspserver.decodePosition(bnr, origPos)
+  endif
+
+  var newPos = AdjustPositionForOnTypeEdits(origPos, reply.result)
+
+  # interface TextEdit
+  # Apply each of the text edit operations
+  textedit.ApplyTextEdits(bnr, reply.result)
+
+  var byteIdx = util.GetLineByteFromPos(bnr, newPos)
+  cursor(newPos.line + 1, byteIdx + 1)
+enddef
+
 def DecodeCallHierarchyItem(lspserver: dict<any>, item: dict<any>)
   if !lspserver.needOffsetEncoding
     return
@@ -2529,6 +2634,7 @@ export def NewLspServer(serverParams: dict<any>): dict<any>
     docHighlight: function(DocHighlight, [lspserver]),
     getDocSymbols: function(GetDocSymbols, [lspserver]),
     textDocFormat: function(TextDocFormat, [lspserver]),
+    textDocOnTypeFormat: function(TextDocOnTypeFormat, [lspserver]),
     prepareCallHierarchy: function(PrepareCallHierarchy, [lspserver]),
     incomingCalls: function(IncomingCalls, [lspserver]),
     getIncomingCalls: function(GetIncomingCalls, [lspserver]),

--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -2440,6 +2440,7 @@ export def NewLspServer(serverParams: dict<any>): dict<any>
     caps: {},
     callHierarchyType: '',
     completionTriggerChars: [],
+    onTypeFormattingTriggers: [],
     customNotificationHandlers: serverParams.customNotificationHandlers->deepcopy(),
     customRequestHandlers: serverParams.customRequestHandlers->deepcopy(),
     debug: serverParams.debug,

--- a/autoload/lsp/ontypeformat.vim
+++ b/autoload/lsp/ontypeformat.vim
@@ -1,0 +1,70 @@
+vim9script
+
+# Functions for on-type formatting (textDocument/onTypeFormatting).  As the
+# user types, when a character the server designates as a trigger character
+# is inserted, request formatting edits for the surrounding text and apply
+# them.  Opt-in via the 'onTypeFormatting' option (see options.vim).
+
+import './options.vim' as opt
+import './buffer.vim' as buf
+
+# Pre-create the (empty) augroup used for the buffer-local trigger autocmd.
+export def InitOnce()
+  augroup LspOnTypeFormatting
+    autocmd!
+  augroup END
+enddef
+
+# Handle a text change in insert mode: detect the character that was just
+# typed and, if it is one of the server's on-type-formatting trigger
+# characters, request on-type formatting for it.
+export def OnTypeFormat(bnr: number)
+  if !opt.lspOptions.onTypeFormatting
+    return
+  endif
+
+  var lspserver: dict<any> = buf.BufLspServerGet(bnr, 'documentOnTypeFormatting')
+  if lspserver->empty() || !lspserver.running || !lspserver.ready
+    return
+  endif
+
+  var curLine = line('.')
+  var prevLine = bnr->getbufvar('LspOnTypeFormatPrevLine', curLine)
+  setbufvar(bnr, 'LspOnTypeFormatPrevLine', curLine)
+
+  var ch: string
+  if curLine > prevLine
+    # A newline was just inserted.
+    ch = "\n"
+  else
+    var col = charcol('.')
+    var curText = getline('.')
+    ch = curText[col - 2]
+  endif
+
+  if ch == '' || lspserver.onTypeFormattingTriggers->index(ch) == -1
+    return
+  endif
+
+  lspserver.textDocOnTypeFormat(ch)
+enddef
+
+# Do buffer-local initialization for on-type formatting.
+export def BufferInit(lspserver: dict<any>, bnr: number)
+  if !lspserver.isDocumentOnTypeFormattingProvider
+    # no support for on-type formatting
+    return
+  endif
+
+  if !lspserver.featureEnabled('documentOnTypeFormatting')
+    return
+  endif
+
+  autocmd_add([{bufnr: bnr,
+		replace: true,
+		event: 'TextChangedI',
+		group: 'LspOnTypeFormatting',
+		cmd: $'OnTypeFormat({bnr})'}])
+enddef
+
+# vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/autoload/lsp/ontypeformat.vim
+++ b/autoload/lsp/ontypeformat.vim
@@ -38,6 +38,12 @@ export def OnTypeFormat(bnr: number)
     ch = "\n"
   else
     var col = charcol('.')
+    if col < 2
+      # Nothing precedes the cursor (e.g. text was deleted back to column
+      # 1); there is no just-typed character to detect.  Negative string
+      # indexing below would otherwise wrap to the end of the line.
+      return
+    endif
     var curText = getline('.')
     ch = curText[col - 2]
   endif

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -119,8 +119,13 @@ export var lspOptions: dict<any> = {
   # Whether or not the omni-completion function can run even if there aren't
   # any characters that would normally trigger the completion.
   # For backwards compatibility, and because this enables quirks like spaces
-  # being enough to trigger the completion popup, this is default-disabled. 
+  # being enough to trigger the completion popup, this is default-disabled.
   omniCompleteAllowBare: false,
+
+  # Reformat code as you type, using the LSP server's on-type formatting
+  # support (e.g. reindenting a line after pressing <Enter>). Opt-in and
+  # disabled by default because it edits the buffer while you are typing.
+  onTypeFormatting: false,
 
   # Open outline window on right side
   outlineOnRight: false,

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -1797,6 +1797,14 @@ omniCompleteAllowBare   |Boolean| option. Defines whether or not the
 			less noisy |lsp-opt-autoComplete| solution, see
 			|lsp-ins-force|
 
+						*lsp-opt-onTypeFormatting*
+onTypeFormatting	|Boolean| option.  Reformat code as you type, using the
+			language server's on-type formatting support (for
+			example, reindenting a line after pressing <Enter>).
+			By default this is set to false, since it edits the
+			buffer while you are typing.  See |lsp-on-type-format|
+			for more information.
+
 						*lsp-opt-outlineOnRight*
 outlineOnRight		|Boolean| option.  When true, open the outline window
 			on the right side of the screen.  When false (the
@@ -2444,6 +2452,13 @@ To format code using the 'gq' command, you can set the 'formatexpr' option: >
 
     setlocal formatexpr=lsp#lsp#FormatExpr()
 <
+						*lsp-on-type-format*
+If the language server supports it and the |lsp-opt-onTypeFormatting| option
+is set to true, code is reformatted as you type, whenever you type one of the
+trigger characters the language server designates (for example, clangd
+reindents the current line when you press <Enter>).  This option is disabled
+by default, since it edits the buffer while you are typing.
+
 ==============================================================================
 							*lsp-call-hierarchy*
 11. Call Hierarchy~

--- a/test/clangd_tests.vim
+++ b/test/clangd_tests.vim
@@ -5,6 +5,7 @@ import '../autoload/lsp/hover.vim' as hover
 import '../autoload/lsp/buffer.vim' as buf
 import '../autoload/lsp/signature.vim' as signature
 import '../autoload/lsp/codeaction.vim' as codeaction
+import '../autoload/lsp/ontypeformat.vim' as ontypeformat
 
 source common.vim
 
@@ -336,6 +337,53 @@ def g:Test_LspFormat_Fallback()
 
   # Restore default to avoid impacting other tests.
   g:LspOptionsSet({formatFallback: false})
+  :%bw!
+enddef
+
+# Test for on-type formatting (opt-in), triggered by typing a newline.
+def g:Test_LspOnTypeFormatting()
+  g:LspOptionsSet({onTypeFormatting: true})
+
+  :silent! edit XLspOnTypeFormat.c
+  sleep 200m
+  var lines = ['int f1() {', 'int i;', '}']
+  setline(1, lines)
+  g:WaitForServerFileLoad(0)
+  :redraw!
+
+  var bnr = bufnr()
+
+  # The on-type-formatting trigger autocmd should be registered for this
+  # buffer, since clangd advertises documentOnTypeFormattingProvider.
+  var acmds = autocmd_get({group: 'LspOnTypeFormatting', bufnr: bnr})
+  assert_equal(1, acmds->len())
+  assert_equal('TextChangedI', acmds[0].event)
+
+  # Simulate the user positioned at the end of the under-indented "int i;"
+  # line pressing Enter: prime the "previous line" state ontypeformat.vim
+  # tracks to detect a newline, apply the newline the same way Vim would,
+  # and invoke the on-type-formatting handler directly.  (Driving this via
+  # feedkeys() and relying on the real TextChangedI autocmd to fire is not
+  # reliable in this test harness -- the same reason the 24x7 completion
+  # tests above call completion.LspComplete() directly instead of typing.)
+  setbufvar(bnr, 'LspOnTypeFormatPrevLine', 2)
+  append(2, '')
+  cursor(3, 1)
+  :startinsert!
+  ontypeformat.OnTypeFormat(bnr)
+  :stopinsert
+
+  # clangd's on-type formatting (triggered on "\n") should reindent the
+  # "int i;" line and the newly created blank line to match the
+  # surrounding braces.
+  var expected = ['int f1() {', '  int i;', '  ', '}']
+  g:WaitForAssert(() => assert_equal(expected, getline(1, '$')))
+  # Cursor should land after the auto-inserted indent, ready to continue
+  # typing, not before it.
+  assert_equal([3, 3], [line('.'), col('.')])
+
+  # Restore default to avoid impacting other tests.
+  g:LspOptionsSet({onTypeFormatting: false})
   :%bw!
 enddef
 

--- a/test/not_lspserver_related_tests.vim
+++ b/test/not_lspserver_related_tests.vim
@@ -3,6 +3,7 @@ vim9script
 
 import '../autoload/lsp/completion.vim' as completion
 import '../autoload/lsp/buffer.vim' as buf
+import '../autoload/lsp/capabilities.vim' as capabilities
 
 # Test for no duplicates in helptags
 def g:Test_Helptags()
@@ -284,6 +285,24 @@ def g:Test_Completion_Preselect_NoopWithoutPreselect()
   assert_equal('gamma', lspserver.completeItems[2].word)
 
   :%bw!
+enddef
+
+# Regression test for documentOnTypeFormattingProvider trigger char capture.
+def g:Test_OnTypeFormattingCapability()
+  var lspserver = {
+    caps: {
+      documentOnTypeFormattingProvider: {
+        firstTriggerCharacter: '}',
+        moreTriggerCharacter: [';', "\n"],
+      }
+    },
+    forceOffsetEncoding: '',
+  }
+
+  capabilities.ProcessServerCaps(lspserver, lspserver.caps)
+
+  assert_true(lspserver.isDocumentOnTypeFormattingProvider)
+  assert_equal(['}', ';', "\n"], lspserver.onTypeFormattingTriggers)
 enddef
 
 # Only here to because the test runner needs it


### PR DESCRIPTION
## 📌 Summary

Adds opt-in support for `textDocument/onTypeFormatting`, so the language server can reformat code as you type — e.g. clangd reindenting the line you just finished when you press `<Enter>`.

---

## 🔍 Related Issues

- Resolves the long-standing TODO in `lsp#lsp#TextDocFormat()`.

---

## 🧪 What This PR Improves

The plugin already detected the `documentOnTypeFormattingProvider` server capability (`isDocumentOnTypeFormattingProvider`), but discarded the trigger characters and never sent the request — so the capability was effectively dead. This wires it up end to end, **opt-in and off by default** since it edits the buffer while you're typing.

---

## 🛠️ Changes Made

- New `onTypeFormatting` option (default `v:false`) in `options.vim`.
- `capabilities.vim`: captures `firstTriggerCharacter`/`moreTriggerCharacter` (previously discarded) and advertises the `onTypeFormatting` client capability.
- New `autoload/lsp/ontypeformat.vim`: buffer-local `TextChangedI` trigger detection, gated by server capability + the option.
- `lspserver.vim`: new `textDocOnTypeFormat` request method, modeled on `:LspFormat`'s `textDocFormat` and reusing `textedit#ApplyTextEdits()`; includes a small cursor-position-adjustment helper, since `ApplyTextEdits()` doesn't track cursor movement and on-type edits routinely insert text immediately before the cursor.
- `buffer.vim` / `lsp.vim`: standard feature-provider wiring (`SupportedCheckFns` entry, `BufferInit` dispatch).
- `doc/lsp.txt`, `README.md`: documented the new option and behavior.

---

## 🧪 Testing

Built test-first (red → green):
- Unit test (`test/not_lspserver_related_tests.vim`, `Test_OnTypeFormattingCapability`) verifies trigger-character extraction from a mock server-capabilities object.
- Integration test (`test/clangd_tests.vim`, `Test_LspOnTypeFormatting`) exercises the full request → response → edit-apply → cursor-placement path against real clangd (v15).

```bash
cd test
./run_tests.sh not_lspserver_related_tests.vim   # unit
./run_tests.sh clangd_tests.vim                  # integration (needs clangd v15)
./run_tests.sh                                   # full regression
```

Manual: open a .c/.cpp file with clangd attached, call LspOptionsSet(#{onTypeFormatting: v:true}), type a badly-indented block and press <Enter> — the line reindents.

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

If yes, explain:

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [x] No  

If yes, describe what needs updating.

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [x] I have updated documentation if needed.
- [x] I have followed the project’s coding style and conventions.
- [x] I have added tests or examples where appropriate.

