### PR TITLE
fix: some var errs

### DIFF
--- a/autoload/lsp/lsp.vim
+++ b/autoload/lsp/lsp.vim
@@ -116,7 +116,8 @@ enddef
 # score, LSP servers with the same score are being returned.
 # Returns an empty list if the servers is not found.
 def LspGetServers(bnr: number, ftype: string): list<dict<any>>
-  if !ftypeServerMap->has_key(ftype)
+  # E1302 var maybe deleted already
+  if !exists('ftypeServerMap') || !ftypeServerMap->has_key(ftype)
     return []
   endif
 
@@ -374,7 +375,8 @@ enddef
 # Get LSP server running status for filetype "ftype"
 # Return true if running, or false if not found or not running
 export def ServerRunning(ftype: string): bool
-  if ftypeServerMap->has_key(ftype)
+  # E1302 var maybe deleted already
+  if exists('ftypeServerMap') && ftypeServerMap->has_key(ftype)
     var lspservers = ftypeServerMap[ftype]
     for lspserver in lspservers
       if lspserver.running
@@ -796,9 +798,10 @@ export def RemoveFile(bnr: number): void
     doautocmd <nomodeline> User LspDetached
   endif
 
-  if bufAttachStates->has_key(bnr)
-    bufAttachStates->remove(bnr)
-  endif
+  # XXX: E1001 var maybe not found since wipeout?
+  # if bufAttachStates->has_key(bnr)
+  #   bufAttachStates->remove(bnr)
+  # endif
 enddef
 
 # Buffer 'bnr' is loaded in a window, refresh visuals and UI state.


### PR DESCRIPTION
## 📌 Summary

somehow these 2 var in lsp.vim would popup errs, looks one is var was deleted, another was not found,
not sure if was a vim9 script itself bug, but for now just trying to workaround it.

## 🧪 What This PR Improves

suspend the errs.
