### PR TITLE
utils: escape URI when calling shell command

### DIFF
--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -204,7 +204,7 @@ export def LspFileToUri(fname: string): string
     # We're in Cygwin, convert POSIX style paths to Windows style.
     # The substitution is to remove the '^@' escape character from the end of
     # line.
-    uri = system($'cygpath -m {uri}')->substitute('^\(\p*\).*$', '\=submatch(1)', "")
+    uri = system($'cygpath -m {uri->shellescape()}')->substitute('^\(\p*\).*$', '\=submatch(1)', "")
   endif
 
   var on_windows: bool = false


### PR DESCRIPTION
In Cygwin, when converting a filename to URI, an external program is used. We should escape this filename before executing the program, because the compilation database might use paths with Windows basckslashes, or spaces, which are not interpreted correctly in Cygwin.

## 📌 Summary

Escape Path with `shellescape()` before calling shell command.

---

## 🧪 What This PR Improves

I had issues with LSP crashing in cygwin if the compilation database used paths native to Windows (like `c:\\Program Files\Micsosoft Visual Studio\blah blah blah`)

---

## 🛠️ Changes Made

List the key changes:
- Escape path before calling shell command. 

---

## 🧪 Testing

Describe how you tested the changes. Include steps, commands, or sample files.

1. Use a database with native windows paths
2. use lsp plugin in vim in cygwin with this patch.
3. Make sure it does not crash

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

If yes, explain:

---

## 📚 Documentation

Does this PR require documentation updates?

- [ ] Yes  
- [x] No  

If yes, describe what needs updating.

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [ ] I have updated documentation if needed.
- [x] I have followed the project’s coding style and conventions.
- [ ] I have added tests or examples where appropriate.

