### PR TITLE
Init server list before plugin load

### DIFF
--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -158,7 +158,8 @@ register a language server for that file type(s).
 
 					*LspAddServer()* *g:LspAddServer()*
 To register one or more language servers, use the LspAddServer() function with
-a list of language server details in the .vimrc file.
+a list of language server details in the .vimrc file, or define the variable
+|g:lsp_servers| before loading the plugin.
 
 To register a language server, add the following lines to your .vimrc file
 (use only the language servers that you need from the below list).
@@ -384,7 +385,7 @@ Additionally the following configurations can be made:
 		    languageId: GetLanguageId,
 		}])
 <
-			This ensures 
+			This ensures
 
 			1. docker-language-server works with docker-compose.yaml
 			2. docker-language-server works with Dockerfile
@@ -485,7 +486,8 @@ function accepts a list of language servers with the above information.
 
 If you used [vim-plug](https://github.com/junegunn/vim-plug) to install the
 LSP plugin, then you need to use the LspSetup User autocmd to initialize the
-language server and to set the language server options.  For example: >
+language server and to set the language server options, or you can set the
+variable |g:lsp_servers|.  For example: >
 
     vim9script
 
@@ -2100,6 +2102,40 @@ Is equivalent to this: >
     vim9script
     var lspOpts = {autoHighlightDiags: true}
     autocmd User LspSetup g:LspOptionsSet(lspOpts)
+<
+						*g:lsp_servers*
+For convenience the server list can also be set through the variable
+|g:lsp_servers| that shall be set before loading the plugin, for example by
+defining it in in your |.vimrc|. The value must be a dictionary, and shall
+support the same options as calling |LspAddServer()|
+directly. |LspAddServer()| is automatically called on plugin load when
+|g:lsp_servers| is set. For example, in your vimrc, this: >
+
+    vim9script
+    var lspServers = [
+		     {
+		        name: 'clangd',
+		        filetype: ['c', 'cpp'],
+		        path: '/usr/local/bin/clangd',
+		        args: ['--background-index']
+		      }
+		   ]
+
+    g:lsp_servers = lspServers
+<
+Is equivalent to this: >
+
+    vim9script
+    var lspServers = [
+		     {
+		        name: 'clangd',
+		        filetype: ['c', 'cpp'],
+		        path: '/usr/local/bin/clangd',
+		        args: ['--background-index']
+		      }
+		   ]
+
+    autocmd User LspSetup g:LspAddServer(lspServers)
 <
 						*g:lsp_enable*
 The plugin is automatically enabled on Vim startup by default. You can use

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -2106,10 +2106,10 @@ Is equivalent to this: >
 						*g:lsp_servers*
 For convenience the server list can also be set through the variable
 |g:lsp_servers| that shall be set before loading the plugin, for example by
-defining it in in your |.vimrc|. The value must be a dictionary, and shall
-support the same options as calling |LspAddServer()|
-directly. |LspAddServer()| is automatically called on plugin load when
-|g:lsp_servers| is set. For example, in your vimrc, this: >
+defining it in in your |.vimrc|. The value must be a list of dictionaries, and
+shall support the same options as calling |LspAddServer()| directly.
+|LspAddServer()| is automatically called on plugin load when |g:lsp_servers|
+is set. For example, in your vimrc, this: >
 
     vim9script
     var lspServers = [

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -176,6 +176,10 @@ if exists('g:lsp_options') && g:lsp_options->type() == v:t_dict
   g:LspOptionsSet(g:lsp_options)
 endif
 
+if exists('g:lsp_servers') && g:lsp_servers->type() == v:t_dict
+  g:LspAddServer(g:lsp_servers)
+endif
+
 if get(g:, 'lsp_enable', true)
   if v:vim_did_enter
     # allow for plugin load, e.g. packadd lsp, after VimEnter

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -176,7 +176,7 @@ if exists('g:lsp_options') && g:lsp_options->type() == v:t_dict
   g:LspOptionsSet(g:lsp_options)
 endif
 
-if exists('g:lsp_servers') && g:lsp_servers->type() == v:t_dict
+if exists('g:lsp_servers') && g:lsp_servers->type() == v:t_list
   g:LspAddServer(g:lsp_servers)
 endif
 


### PR DESCRIPTION
## 📌 Summary

Provide a clear and concise description of the changes in this PR.

Added config variable `g:lsp_servers` to simplify the plugin configuration when it comes to register LSP servers.

## 🔍 Related Issues

Link any related issues or discussions:

- Closes #823 


---

## 🧪 What This PR Improves

Simplification of LSP servers registration.

---

## 🛠️ Changes Made

List the key changes:

- Added `g:lsp_servers` variable

---

## 🧪 Testing

I just registered the servers through the new variable and tested the registered lsp. 

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  


## 📚 Documentation

Does this PR require documentation updates?

- [x] Yes  
- [ ] No  

If yes, describe what needs updating.

Docs have been updated. 

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [x] I have updated documentation if needed.
- [x] I have followed the project’s coding style and conventions.
- [ ] I have added tests or examples where appropriate.

