### PR TITLE
Fix incremental sync corrupting the document on multi-hunk edits

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -674,6 +674,20 @@ def HunkText(newBufLines: list<string>, hunk: dict<number>, hasEol: bool): strin
   return text
 enddef
 
+# Length of "line" in the position encoding negotiated with the server
+# ("posEncoding": 8, 16 or 32).  Used to anchor a range to the end of a line
+# that only exists in a cached (old-document) snapshot, so
+# offset.EncodePosition() (which reads the live buffer) doesn't apply.
+def EncodedLineLen(lspserver: dict<any>, line: string): number
+  if lspserver.posEncoding == 8
+    return line->strlen()
+  elseif lspserver.posEncoding == 16
+    return line->strutf16len(true)
+  else
+    return line->strchars()
+  endif
+enddef
+
 # Send a file/document opened notification to the language server.
 def TextdocDidOpen(lspserver: dict<any>, bnr: number, ftype: string): void
   # Notification: 'textDocument/didOpen'
@@ -690,6 +704,7 @@ def TextdocDidOpen(lspserver: dict<any>, bnr: number, ftype: string): void
 
   var newBufLines = bnr->getbufline(1, '$')
   lspserver.cachedBufferContent[bnr] = newBufLines
+  lspserver.cachedBufferEol[bnr] = bnr->getbufvar('&eol')
 
   if !lspserver.supportsDidOpenClose
     return
@@ -722,6 +737,9 @@ def TextdocDidClose(lspserver: dict<any>, bnr: number): void
   endif
   if lspserver.cachedBufferContent->has_key(bnr)
     lspserver.cachedBufferContent->remove(bnr)
+  endif
+  if lspserver.cachedBufferEol->has_key(bnr)
+    lspserver.cachedBufferEol->remove(bnr)
   endif
   if lspserver.diagnosticResultIds->has_key(bnr)
     lspserver.diagnosticResultIds->remove(bnr)
@@ -881,26 +899,56 @@ def TextdocDidChange(lspserver: dict<any>, bnr: number): void
     var newBufLines = bnr->getbufline(1, '$')
     var hasEol = bnr->getbufvar('&eol')
     var cachedBufferContent = lspserver.cachedBufferContent
+    var cachedBufferEol = lspserver.cachedBufferEol
     if cachedBufferContent->has_key(bnr)
+	&& cachedBufferEol[bnr] == hasEol
       # Compute line-level diffs against the last snapshot and convert each
-      # hunk into an LSP TextDocumentContentChangeEvent.
+      # hunk into an LSP TextDocumentContentChangeEvent.  Hunks are emitted
+      # bottom-up: the LSP spec applies contentChanges entries sequentially,
+      # so a top-down hunk's range would be interpreted against a document
+      # already shifted by an earlier hunk in the same notification.
       contentChanges = []
-      var diffs = diff(cachedBufferContent[bnr], newBufLines,
-		       {output: 'indices'})
-      for hunk in diffs
+      var oldBufLines = cachedBufferContent[bnr]
+      var oldLineCount = oldBufLines->len()
+      var diffs = diff(oldBufLines, newBufLines, {output: 'indices'})
+      for hunk in diffs->copy()->reverse()
+	var startLine = hunk.from_idx
+	var startChar = 0
+	var endLine = hunk.from_idx + hunk.from_count
+	var endChar = 0
+	var text = HunkText(newBufLines, hunk, hasEol)
+	if !hasEol && endLine == oldLineCount
+	  # The old document has no trailing newline, so
+	  # {line: oldLineCount, character: 0} isn't a valid position in it;
+	  # anchor to the end of the last line instead.  When the hunk
+	  # doesn't start at the first line, pull the start back over the
+	  # newline that precedes it too, so that line's break is removed.
+	  endLine = oldLineCount - 1
+	  endChar = EncodedLineLen(lspserver, oldBufLines[endLine])
+	  if startLine > 0
+	    startLine -= 1
+	    startChar = EncodedLineLen(lspserver, oldBufLines[startLine])
+	    if !text->empty()
+	      text = "\n" .. text
+	    endif
+	  endif
+	endif
 	contentChanges->add({
 	  range: {
-	    start: {line: hunk.from_idx, character: 0},
-	    end:   {line: hunk.from_idx + hunk.from_count, character: 0}
+	    start: {line: startLine, character: startChar},
+	    end:   {line: endLine, character: endChar}
 	  },
-	  text: HunkText(newBufLines, hunk, hasEol)
+	  text: text
 	})
       endfor
     else
-      # No cached snapshot available; fall back to a full-text change.
+      # No cached snapshot available, or its line-ending state doesn't
+      # match the current buffer (the old-document end-of-file math above
+      # would be wrong); fall back to a full-text change.
       contentChanges = [{text: LinesText(newBufLines, hasEol)}]
     endif
     cachedBufferContent[bnr] = newBufLines
+    cachedBufferEol[bnr] = hasEol
   endif
 
   if contentChanges->empty()
@@ -2606,6 +2654,7 @@ export def NewLspServer(serverParams: dict<any>): dict<any>
     selection: {},
     signaturePopup: -1,
     cachedBufferContent: {},
+    cachedBufferEol: {},
     syncInit: serverParams.syncInit,
     traceLevel: serverParams.traceLevel,
     typeHierFilePopup: -1,

--- a/test/stub_lspserver_tests.vim
+++ b/test/stub_lspserver_tests.vim
@@ -1492,6 +1492,11 @@ def g:Test_TextdocDidChange_IncrementalSync_MultiHunkDeleteAppliesBottomUp()
   # Regression test for #836: ":%d" produces two diff hunks; emitting them
   # top-down sends the second hunk's range against a document already
   # shrunk by the first, desyncing the server.
+  if !exists('*diff')
+    # incrementalSync needs diff(); options.OptionsSet() forces it back off
+    # without it, same as the plugin itself falling back to full sync.
+    return
+  endif
   g:LspOptionsSet({incrementalSync: true})
   silent! edit XIncrementalMultiHunkDelete.c
   var oldLines = ['#include <stdio.h>', '', 'int main() {',
@@ -1523,6 +1528,9 @@ def g:Test_TextdocDidChange_IncrementalSync_MultiHunkDeleteAppliesBottomUp()
 enddef
 
 def g:Test_TextdocDidChange_IncrementalSync_MultiHunkInsertDescendingOrder()
+  if !exists('*diff')
+    return
+  endif
   g:LspOptionsSet({incrementalSync: true})
   silent! edit XIncrementalMultiHunkInsert.txt
   var oldLines = ['one', 'two', 'three']
@@ -1554,6 +1562,9 @@ def g:Test_TextdocDidChange_IncrementalSync_NoEolAnchorsToLastLineEnd()
   # Regression test: without a trailing newline, a hunk reaching the end of
   # the document must anchor to the end of the last line, not to a
   # {line: lineCount, character: 0} position that doesn't exist.
+  if !exists('*diff')
+    return
+  endif
   g:LspOptionsSet({incrementalSync: true})
   silent! edit XIncrementalNoEol.txt
   var oldLines = ['abc', 'def', 'ghi']

--- a/test/stub_lspserver_tests.vim
+++ b/test/stub_lspserver_tests.vim
@@ -1569,7 +1569,7 @@ def g:Test_TextdocDidChange_IncrementalSync_NoEolAnchorsToLastLineEnd()
   silent! edit XIncrementalNoEol.txt
   var oldLines = ['abc', 'def', 'ghi']
   setline(1, oldLines)
-  set noeol
+  setlocal noeol
 
   var notifications: list<dict<any>> = []
   var lspserver = MakeTestLspServer(notifications)

--- a/test/stub_lspserver_tests.vim
+++ b/test/stub_lspserver_tests.vim
@@ -41,6 +41,9 @@ def MakeTestLspServer(notifications: list<dict<any>>): dict<any>
 	workspaceConfig: {}
       })
   lspserver.textDocumentSync = 2
+  # Not set by NewLspServer() -- only assigned while processing the
+  # "initialize" response -- but the incremental-sync code path needs it.
+  lspserver.posEncoding = 32
   lspserver.sendNotification = function(CaptureNotification, [notifications])
   return lspserver
 enddef
@@ -1483,6 +1486,97 @@ def g:Test_LspAutoFix_Range_MultiServer_WaitsForAllReplies()
   buf.BufLspServerRemove(bufnr(), srvErr)
   buf.BufLspServerRemove(bufnr(), srvOk)
   :bw!
+enddef
+
+def g:Test_TextdocDidChange_IncrementalSync_MultiHunkDeleteAppliesBottomUp()
+  # Regression test for #836: ":%d" produces two diff hunks; emitting them
+  # top-down sends the second hunk's range against a document already
+  # shrunk by the first, desyncing the server.
+  g:LspOptionsSet({incrementalSync: true})
+  silent! edit XIncrementalMultiHunkDelete.c
+  var oldLines = ['#include <stdio.h>', '', 'int main() {',
+	'    printf("hello world\n");', '    return 0;', '}']
+  setline(1, oldLines)
+
+  var notifications: list<dict<any>> = []
+  var lspserver = MakeTestLspServer(notifications)
+  var bnr = bufnr()
+  lspserver.cachedBufferContent[bnr] = oldLines
+  lspserver.cachedBufferEol[bnr] = true
+
+  :%d
+  lspserver.textdocDidChange(bnr)
+
+  assert_equal(1, notifications->len())
+  assert_equal('textDocument/didChange', notifications[0].method)
+  var changes = notifications[0].params.contentChanges
+  assert_equal(2, changes->len())
+  assert_equal({line: 2, character: 0}, changes[0].range.start)
+  assert_equal({line: 6, character: 0}, changes[0].range.end)
+  assert_equal('', changes[0].text)
+  assert_equal({line: 0, character: 0}, changes[1].range.start)
+  assert_equal({line: 1, character: 0}, changes[1].range.end)
+  assert_equal('', changes[1].text)
+
+  g:LspOptionsSet({incrementalSync: false})
+  :%bw!
+enddef
+
+def g:Test_TextdocDidChange_IncrementalSync_MultiHunkInsertDescendingOrder()
+  g:LspOptionsSet({incrementalSync: true})
+  silent! edit XIncrementalMultiHunkInsert.txt
+  var oldLines = ['one', 'two', 'three']
+  setline(1, oldLines)
+
+  var notifications: list<dict<any>> = []
+  var lspserver = MakeTestLspServer(notifications)
+  var bnr = bufnr()
+  lspserver.cachedBufferContent[bnr] = oldLines
+  lspserver.cachedBufferEol[bnr] = true
+
+  setline(1, ['zero', 'one', 'two', 'inserted', 'three'])
+  lspserver.textdocDidChange(bnr)
+
+  var changes = notifications[0].params.contentChanges
+  assert_equal(2, changes->len())
+  assert_equal({line: 2, character: 0}, changes[0].range.start)
+  assert_equal({line: 2, character: 0}, changes[0].range.end)
+  assert_equal("inserted\n", changes[0].text)
+  assert_equal({line: 0, character: 0}, changes[1].range.start)
+  assert_equal({line: 0, character: 0}, changes[1].range.end)
+  assert_equal("zero\n", changes[1].text)
+
+  g:LspOptionsSet({incrementalSync: false})
+  :%bw!
+enddef
+
+def g:Test_TextdocDidChange_IncrementalSync_NoEolAnchorsToLastLineEnd()
+  # Regression test: without a trailing newline, a hunk reaching the end of
+  # the document must anchor to the end of the last line, not to a
+  # {line: lineCount, character: 0} position that doesn't exist.
+  g:LspOptionsSet({incrementalSync: true})
+  silent! edit XIncrementalNoEol.txt
+  var oldLines = ['abc', 'def', 'ghi']
+  setline(1, oldLines)
+  set noeol
+
+  var notifications: list<dict<any>> = []
+  var lspserver = MakeTestLspServer(notifications)
+  var bnr = bufnr()
+  lspserver.cachedBufferContent[bnr] = oldLines
+  lspserver.cachedBufferEol[bnr] = false
+
+  :$d
+  lspserver.textdocDidChange(bnr)
+
+  var changes = notifications[0].params.contentChanges
+  assert_equal(1, changes->len())
+  assert_equal({line: 1, character: 3}, changes[0].range.start)
+  assert_equal({line: 2, character: 3}, changes[0].range.end)
+  assert_equal('', changes[0].text)
+
+  g:LspOptionsSet({incrementalSync: false})
+  :%bw!
 enddef
 
 # Only here to because the test runner needs it


### PR DESCRIPTION
## Summary

`textDocument/didChange` `contentChanges` entries are applied sequentially per the LSP spec, but `diff()` hunks were emitted top-down in old-document coordinates. Whenever an edit produced 2+ hunks (e.g. `:%d`), the second hunk's range was interpreted against a document already shifted by the first, desyncing the server's copy of the file. This is what #836 reports.

Emitting the hunks bottom-up keeps each hunk's range valid, since the document above an unprocessed hunk hasn't shifted yet.

While verifying this against `'noeol'` buffers, I also found that a hunk reaching the end of a document without a trailing newline could target a `{line: lineCount, character: 0}` position, which doesn't exist in that document. This anchors that case to the end of the actual last line instead, and tracks each snapshot's `'eol'` state so a runtime toggle falls back to a full-text change rather than reusing a stale assumption.

## Test plan

- [x] Added regression tests in `test/stub_lspserver_tests.vim` asserting the exact `contentChanges` ranges for a multi-hunk delete, a multi-hunk insert, and a `noeol` end-of-file edit
- [x] `./run_tests.sh stub_lspserver_tests.vim`, `markdown_tests.vim`, `not_lspserver_related_tests.vim`, `gopls_tests.vim` all pass
- [x] Manually reproduced the issue against real clangd: opened the reporter's file, enabled `incrementalSync` + `semanticHighlight`, ran `:%d` — no error, and the traffic log shows the corrected bottom-up `contentChanges` order

Fixes #836