### PR TITLE
fix: null workspace root for ignored paths (#843)

### DIFF
--- a/autoload/lsp/lspserver.vim
+++ b/autoload/lsp/lspserver.vim
@@ -210,15 +210,26 @@ def InitServer(lspserver: dict<any>, bnr: number)
   endif
 
   rootPath = rootPath->fnamemodify(':p')
-  lspserver.workspaceFolders = [rootPath]
 
-  var rootUri = util.LspFileToUri(rootPath)
-  initparams.rootPath = rootPath
-  initparams.rootUri = rootUri
-  initparams.workspaceFolders = [{
-	name: rootPath->fnamemodify(':t'),
-	uri: rootUri
-     }]
+  if util.IsIgnoredRoot(rootPath, opt.lspOptions.workspaceIgnoredPaths)
+    rootPath = ''
+  endif
+
+  if rootPath->empty()
+    lspserver.workspaceFolders = []
+    initparams.rootPath = v:null
+    initparams.rootUri = v:null
+    initparams.workspaceFolders = []
+  else
+    lspserver.workspaceFolders = [rootPath]
+    var rootUri = util.LspFileToUri(rootPath)
+    initparams.rootPath = rootPath
+    initparams.rootUri = rootUri
+    initparams.workspaceFolders = [{
+      name: rootPath->fnamemodify(':t'),
+      uri: rootUri
+    }]
+  endif
 
   initparams.trace = 'off'
   initparams.capabilities = capabilities.GetClientCaps()

--- a/autoload/lsp/options.vim
+++ b/autoload/lsp/options.vim
@@ -243,7 +243,10 @@ export var lspOptions: dict<any> = {
   documentationFormat: ['markdown', 'plaintext'],
 
   # incremental text document sync with the server
-  incrementalSync: false
+  incrementalSync: false,
+
+  # list of directories that should never be used as workspace root
+  workspaceIgnoredPaths: ['/', $"{$HOME}", $"{$HOME}/.cargo", $"{$HOME}/.cargo/**", $"{$HOME}/.rustup", $"{$HOME}/.rustup/**", $"{$HOME}/pkg/mod", $"{$HOME}/pkg/mod/**"]
 }
 
 # set the LSP plugin options from the user provided option values

--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -451,10 +451,11 @@ export def IsIgnoredRoot(rootPath: string, ignoredPaths: list<string>): bool
   for ignored in ignoredPaths
     var globpos: number = ignored->match('[*?[]')
     if globpos != -1
-      # Resolve only the path prefix. if slice part of ignored path, then true
-      var resolvedPattern: string =
-	$'{ignored[0 : globpos - 1]->resolve()->fnamemodify(':p')}{ignored[globpos : ]}'
-      for pattern in [ignored, resolvedPattern]
+      var patterns: list<string> = [ignored]
+      if globpos > 0
+        patterns->add($'{ignored[0 : globpos - 1]->resolve()->fnamemodify(':p')}{ignored[globpos : ]}')
+      endif
+      for pattern in patterns
         var patternRegexp: string = glob2regpat(pattern)
         if rootPath =~ patternRegexp || rootResolved =~ patternRegexp
           return true

--- a/autoload/lsp/util.vim
+++ b/autoload/lsp/util.vim
@@ -444,4 +444,27 @@ export def FindNearestRootDir(startDir: string, files: list<any>): string
   return sortedList[0]
 enddef
 
+# returns true if rootPath (or its resolved form) matches an ignored path
+# in 'workspaceIgnoredPaths' option.
+export def IsIgnoredRoot(rootPath: string, ignoredPaths: list<string>): bool
+  var rootResolved: string = rootPath->resolve()->fnamemodify(':p')
+  for ignored in ignoredPaths
+    var globpos: number = ignored->match('[*?[]')
+    if globpos != -1
+      # Resolve only the path prefix. if slice part of ignored path, then true
+      var resolvedPattern: string =
+	$'{ignored[0 : globpos - 1]->resolve()->fnamemodify(':p')}{ignored[globpos : ]}'
+      for pattern in [ignored, resolvedPattern]
+        var patternRegexp: string = glob2regpat(pattern)
+        if rootPath =~ patternRegexp || rootResolved =~ patternRegexp
+          return true
+        endif
+      endfor
+    elseif rootPath == ignored || rootResolved == ignored->resolve()->fnamemodify(':p')
+      return true
+    endif
+  endfor
+  return false
+enddef
+
 # vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab

--- a/doc/lsp.txt
+++ b/doc/lsp.txt
@@ -2094,6 +2094,18 @@ incrementalSync		|Boolean| option.  Specifies the method used to
 
 			Default: |false|
 
+						*lsp-opt-workspaceIgnoredPaths*
+workspaceIgnoredPaths	|List| option.  Directory paths that are never
+			used as the workspace root for any language server.
+			If the resolved workspace root matches an entry, a
+			null root is sent to the server so it only analyzes
+			the current buffer.  Glob patterns are supported.
+
+			Default:
+ 			['/', $"{$HOME}", $"{$HOME}/.cargo", $"{$HOME}/.cargo/**",
+ 			$"{$HOME}/.rustup", $"{$HOME}/.rustup/**", $"{$HOME}/pkg/mod",
+ 			$"{$HOME}/pkg/mod/**"]
+
 For example, to disable the automatic placement of signs for the LSP
 diagnostic messages, you can add the following line to your .vimrc file: >
 

--- a/test/not_lspserver_related_tests.vim
+++ b/test/not_lspserver_related_tests.vim
@@ -4,6 +4,7 @@ vim9script
 import '../autoload/lsp/completion.vim' as completion
 import '../autoload/lsp/buffer.vim' as buf
 import '../autoload/lsp/capabilities.vim' as capabilities
+import '../autoload/lsp/util.vim' as util
 
 # Test for no duplicates in helptags
 def g:Test_Helptags()
@@ -308,6 +309,37 @@ enddef
 # Only here to because the test runner needs it
 def g:StartLangServer(): bool
   return true
+enddef
+
+# Regression test for $HOME as workspace root being ignored
+def g:Test_WorkspaceIgnoredPaths_HomeRoot()
+  var ignored: list<string> = [$"{$HOME}"]
+  var root: string = $HOME
+  assert_true(util.IsIgnoredRoot(root, ignored))
+enddef
+
+# Glob pattern matches children even under a symlink
+def g:Test_WorkspaceIgnoredPaths_GlobSymlink()
+  var tmpdir: string = tempname()
+  var real: string = $'{tmpdir}/real'
+  var link: string = $'{tmpdir}/link'
+  mkdir($'{real}/.cargo/registry/src/index', 'p')
+  system($'ln -s {shellescape(real)} {shellescape(link)}')
+  assert_equal(0, v:shell_error)
+  var ignored: list<string> = [$'{link}/.cargo/**']
+  var root: string = $'{real}/.cargo/registry/src/index/package'
+  try
+    assert_true(util.IsIgnoredRoot(root, ignored))
+  finally
+    delete(tmpdir, 'rf')
+  endtry
+enddef
+
+# Root not ignored if it doesn't exist in the list
+def g:Test_WorkspaceIgnoredPaths_NormalRoot()
+  var ignored: list<string> = [$"{$HOME}"]
+  var root: string = $"{$HOME}/project"
+  assert_false(util.IsIgnoredRoot(root, ignored))
 enddef
 
 # vim: tabstop=8 shiftwidth=2 softtabstop=2 noexpandtab


### PR DESCRIPTION
## 📌 Summary

Adds a global `workspaceIgnoredPaths` option that prevents the plugin from sending the user's home directory as the workspace root to language servers. When the resolved root matches an ignored path, a `v:null` is used instead. Servers would then only use the current buffer rather than `$HOME` recursively.

---

## 🔍 Related Issues

- Closes #843 

---

## 🧪 What This PR Improves

Fixes memory/CPU ballooning when editing files at or from $HOME.

---

## 🛠️ Changes Made

- Adds `workspaceIgnoredPaths` option (list of paths).
- Expands symlinks with `resolve()` and globs with `glob2regpat()`

---

## 🧪 Testing

Without this fix, opening something from `$HOME` would result in using 4x the amount of RAM and much more CPU. With this change that no longer happens.

`:LspWorkspaceListFolders` doesn't return anything when opening vim from `$HOME`.

---

## 📦 Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes  
- [x] No  

If yes, explain:

---

## 📚 Documentation

Does this PR require documentation updates?

- [x] Yes  
- [ ] No  

If yes, describe what needs updating.

---

## ✔️ Checklist

- [x] I have tested this with a minimal Vim9script configuration.
- [x] I have run the plugin against the relevant LSP server(s).
- [x] I have updated documentation if needed.
- [x] I have followed the project’s coding style and conventions.
- [x] I have added tests or examples where appropriate.

